### PR TITLE
R To Generated Assets

### DIFF
--- a/Sources/SUR/CLI.swift
+++ b/Sources/SUR/CLI.swift
@@ -6,6 +6,10 @@ import SURCore
 
 @main
 struct CLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        subcommands: [RewriteRImage.self],
+        defaultSubcommand: CLI.self
+    )
     @Option(name: .shortAndLong, help: "Root path of your Xcode project. Default is current.", transform: { Path($0) })
     var project: Path?
     
@@ -80,5 +84,51 @@ struct RuntimeError: Error, CustomStringConvertible {
     
     init(_ description: String) {
         self.description = description.red.bold
+    }
+}
+
+extension CLI {
+    struct RewriteRImage: ParsableCommand {
+        static let configuration = CommandConfiguration(commandName: "rewrite-r-image", abstract: "Rewrite R.image.<id>()! to UIImage(resource: .<id>)")
+
+        @Option(name: .shortAndLong, help: "Path to folder or file to rewrite. Default is current.", transform: { Path($0) })
+        var path: Path = Path(".")
+
+        func validate() throws {
+            guard path.exists else { throw RuntimeError("Path does not exist") }
+        }
+
+        func run() throws {
+            var changed = 0
+            let rewriter = RToGeneratedAssetsRewriter()
+
+            let files: [Path]
+            if path.isDirectory {
+                files = try collectSwiftFiles(in: path)
+            } else {
+                files = path.extension == "swift" ? [path] : []
+            }
+
+            for file in files {
+                if try rewriter.rewrite(fileAt: file.url) { changed += 1 }
+            }
+
+            print("Rewrote \(changed) files")
+        }
+
+        private func collectSwiftFiles(in root: Path) throws -> [Path] {
+            let skipDirs: Set<String> = [".build", ".git", ".swiftpm", "DerivedData", "Carthage", "Pods"]
+            var result: [Path] = []
+
+            for child in try root.children() {
+                if child.isDirectory {
+                    if skipDirs.contains(child.lastComponent) { continue }
+                    result.append(contentsOf: try collectSwiftFiles(in: child))
+                } else if child.extension == "swift" {
+                    result.append(child)
+                }
+            }
+            return result
+        }
     }
 }

--- a/Sources/SURCore/Explorer.swift
+++ b/Sources/SURCore/Explorer.swift
@@ -362,7 +362,7 @@ private extension Configuration.Kind {
     }
 }
 
-private extension String {
+extension String {
     func withoutImageAndColor() -> String {
         let input = self
         let pattern = "(?i)(image|color)+$"

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -198,7 +198,7 @@ private extension RToGeneratedAssetsRewriter.Rewriter {
         return (kind, identifier)
     }
     
-    /// creates an expression for module
+    /// Creates an expression for module.
     private func expr(for kind: Kind, with identifier: String, from module: Module) -> ExprSyntax {
         changedModules.insert(module)
         let resource = kind.resource(for: module, with: identifier.withoutImageAndColor())

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+
+public struct RToGeneratedAssetsRewriter: Sendable {
+    public init() {}
+
+    /// Rewrites the given Swift source file in-place.
+    /// - Returns: true if the file changed.
+    @discardableResult
+    public func rewrite(fileAt url: URL) throws -> Bool {
+        let original = try String(contentsOf: url)
+        let source = Parser.parse(source: original)
+        let rewriter = Rewriter()
+        let transformed = rewriter.rewrite(source)
+        let newText = String(describing: transformed)
+
+        if newText != original {
+            try newText.write(to: url, atomically: true, encoding: .utf8)
+            return true
+        }
+        return false
+    }
+
+    /// Rewriter that converts `R.image.<identifier>()!` -> `UIImage(resource: .<identifier>)`.
+    private final class Rewriter: SyntaxRewriter {
+        override func visit(_ node: ForceUnwrapExprSyntax) -> ExprSyntax {
+            // Match pattern: (FunctionCallExprSyntax)! where call is R.image.<id>()
+            if let call = node.expression.as(FunctionCallExprSyntax.self),
+               let replacement = replaceRImageCall(call) {
+                return ExprSyntax(replacement)
+            }
+            return ExprSyntax(super.visit(node))
+        }
+
+        // Also support replacing direct function calls without force unwrap.
+        override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+            if let replacement = replaceRImageCall(node) {
+                return ExprSyntax(replacement)
+            }
+            return ExprSyntax(super.visit(node))
+        }
+
+        private func replaceRImageCall(_ call: FunctionCallExprSyntax) -> ExprSyntax? {
+            // Ensure no arguments in the call `()`
+            if !call.arguments.isEmpty { return nil }
+
+            // calledExpression must be a member access like `R.image.<id>`
+            guard let lastMember = call.calledExpression.as(MemberAccessExprSyntax.self) else { return nil }
+
+            let identifier = lastMember.declName.baseName.text
+
+            // Base must be `R.image`
+            guard let mid = lastMember.base?.as(MemberAccessExprSyntax.self),
+                  mid.declName.baseName.text == "image",
+                  let first = mid.base?.as(DeclReferenceExprSyntax.self),
+                  first.baseName.text == "R" else {
+                return nil
+            }
+
+            let processed = stripImageSuffix(identifier)
+
+            // Build `UIImage(resource: .<processed>)` expression via parsing
+            let exprText = "UIImage(resource: .\(processed))"
+            return parseExpr(exprText)
+        }
+
+        private func stripImageSuffix(_ name: String) -> String {
+            let lower = name.lowercased()
+            if lower.hasSuffix("image"), name.count > 5 {
+                return String(name.dropLast(5))
+            }
+            return name
+        }
+
+        private func parseExpr(_ text: String) -> ExprSyntax {
+            // Parse a tiny source text as expression: we wrap it in a dummy file
+            let file = Parser.parse(source: text)
+            if let item = file.statements.first?.item.as(ExprSyntax.self) {
+                return item
+            }
+            return ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(text)))
+        }
+    }
+}

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -27,7 +27,11 @@ public struct RToGeneratedAssetsRewriter: Sendable {
         override func visit(_ node: ForceUnwrapExprSyntax) -> ExprSyntax {
             // Match pattern: (FunctionCallExprSyntax)! where call is R.image.<id>()
             if let call = node.expression.as(FunctionCallExprSyntax.self),
-               let replacement = replaceRImageCall(call) {
+               let baseReplacement = replaceRImageCall(call) {
+                // Preserve original trivia around the force-unwrap expression
+                let replacement = baseReplacement
+                    .with(\.leadingTrivia, node.leadingTrivia)
+                    .with(\.trailingTrivia, node.trailingTrivia)
                 return ExprSyntax(replacement)
             }
             return ExprSyntax(super.visit(node))
@@ -35,7 +39,11 @@ public struct RToGeneratedAssetsRewriter: Sendable {
 
         // Also support replacing direct function calls without force unwrap.
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-            if let replacement = replaceRImageCall(node) {
+            if let baseReplacement = replaceRImageCall(node) {
+                // Preserve original trivia of the function call
+                let replacement = baseReplacement
+                    .with(\.leadingTrivia, node.leadingTrivia)
+                    .with(\.trailingTrivia, node.trailingTrivia)
                 return ExprSyntax(replacement)
             }
             return ExprSyntax(super.visit(node))

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -237,14 +237,6 @@ private extension RToGeneratedAssetsRewriter.Rewriter {
         return nil
     }
 
-    private func stripSuffix(_ name: String, _ suffix: String) -> String {
-        let lower = name.lowercased()
-        if lower.hasSuffix(suffix), name.count > suffix.count {
-            return String(name.dropLast(suffix.count))
-        }
-        return name
-    }
-
     private func parseExpr(_ text: String) -> ExprSyntax {
         // Parse a tiny source text as expression: we wrap it in a dummy file
         let file = Parser.parse(source: text)


### PR DESCRIPTION
This pull request adds a new CLI subcommand for rewriting asset references in Swift source files and introduces a core rewriter utility to handle the transformation. The changes enable automated conversion of `R.image.<id>()!` patterns to the modern `UIImage(resource: .<id>)` syntax, supporting both UIKit and SwiftUI asset usages. The implementation includes file traversal logic, error handling, and ensures necessary imports are added when rewriting files.

### CLI enhancements

* Added a new `rewrite-r-image` subcommand to the CLI, allowing users to rewrite asset references in a specified file or directory. The subcommand validates the path, traverses directories (skipping build and dependency folders), and reports the number of files changed. (`Sources/SUR/CLI.swift`) [[1]](diffhunk://#diff-201b209e37d9480808e013bebe4b11de5c67d58369d1d4be1ec896d332122f57R9-R12) [[2]](diffhunk://#diff-201b209e37d9480808e013bebe4b11de5c67d58369d1d4be1ec896d332122f57R89-R134)

### Core asset rewriting functionality

* Introduced the `RToGeneratedAssetsRewriter` utility, which parses Swift files and rewrites `R.image.<id>()!` and similar patterns to `UIImage(resource: .<id>)` for UIKit, and to `Image(.<id>)` for SwiftUI. The rewriter also ensures necessary imports (`UIKit` or `SwiftUI`) are added if missing. (`Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift`)

### Utility improvements

* Made the `withoutImageAndColor()` string helper available outside its original scope by changing its extension from private to public, supporting the rewriter's logic for resource identifier normalization. (`Sources/SURCore/Explorer.swift`)