### PR TITLE
Localization symbols

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ opt_in_rules:
   - closure_spacing
   - collection_alignment
   - comma_inheritance
+  - conditional_returns_on_newline
   - contains_over_filter_count
   - contains_over_filter_is_empty
   - contains_over_first_not_nil
@@ -30,6 +31,8 @@ opt_in_rules:
   - enum_case_associated_values_count
   - expiring_todo
   - explicit_init
+  - fallthrough
+  - fatal_error_message
   - file_name_no_space
   - first_where
   - flatmap_over_map_reduce
@@ -58,6 +61,7 @@ opt_in_rules:
   - override_in_extension
   - pattern_matching_keywords
   - period_spacing
+  - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self
   - prefer_zero_over_explicit_init
   - prefixed_toplevel_constant
@@ -69,6 +73,7 @@ opt_in_rules:
   - required_enum_case
   - return_value_from_void_function
   - self_binding
+  - shorthand_optional_binding
   - sorted_first_last
   - static_operator
   - toggle_bool
@@ -137,7 +142,6 @@ opt_in_rules:
   # - no_extension_access_modifier # (extension_access_modifier)
 
   # Нужен рефакторинг
-  - fatal_error_message
   - file_header
   - file_name
   # - file_types_order
@@ -147,7 +151,6 @@ opt_in_rules:
   - private_action
   - private_outlet
   - redundant_self_in_closure
-  - shorthand_optional_binding
   - sorted_imports
   - strict_fileprivate
   - strong_iboutlet
@@ -155,8 +158,6 @@ opt_in_rules:
 
   # Можно использовать в фреймворках
   # - missing_docs
-
-
 
 type_contents_order:
   order:
@@ -168,49 +169,91 @@ type_contents_order:
     - ib_inspectable
     - ib_outlet
     - instance_property
+    - subscript
     - initializer
     - view_life_cycle_method
     - other_method
     - ib_action
-    - subscript
     - subtype
     - deinitializer
 
 trailing_whitespace:
   ignores_empty_lines: true
 
-implicit_return:
-  included:
-    - closure
-    - getter
-
 indentation_width:
   include_comments: false
   include_multiline_strings: false
+  severity: error
 
 statement_position:
   statement_mode: uncuddled_else
+  severity: error
 
 line_length:
   warning: 180
   ignores_urls: true
+  ignores_comments: true
+
+redundant_void_return:
+  include_closures: false
 
 type_body_length: 
-  warning: 225
+  warning: 350
+  error: 350
 
 nesting:
-  type_level:
-    warning: 5
+  function_level: 1
+  type_level: 5 # Можно поднять, если есть проблема с енамами неймспейсами
 
 identifier_name:
-  min_length: 1
-  max_length: 65
+  min_length:
+    warning: 1
+    error: 1
+  max_length:
+    warning: 50
+    error: 60
 
 type_name:
-  min_length: 3
-  max_length: 65
-  excluded: 
-    - ID
-    - Ad
+  min_length:
+    warning: 2
+    error: 2
+  max_length:
+    warning: 65
+    error: 65
 
-large_tuple: 4
+generic_type_name:
+  max_length:
+    warning: 25
+    error: 30
+
+large_tuple:
+  warning: 4
+  error: 4
+
+cyclomatic_complexity:
+  ignores_case_statements: true
+
+function_body_length:
+  warning: 120
+  error: 200
+
+closure_body_length:
+  warning: 50
+  error: 60
+
+enum_case_associated_values_count:
+  warning: 6
+  error: 6
+
+file_length:
+  warning: 500
+  error: 600
+
+function_parameter_count:
+  warning: 8
+  error: 10
+
+opening_brace:
+  ignore_multiline_type_headers: true
+  ignore_multiline_statement_conditions: true
+  ignore_multiline_function_signatures: true

--- a/Sources/SUR/CLI.swift
+++ b/Sources/SUR/CLI.swift
@@ -101,6 +101,7 @@ extension CLI {
         func run() throws {
             var changed = 0
             let rewriter = RToGeneratedAssetsRewriter()
+            let stringsRewriter = RToGeneratedStringsRewriter(projectAt: path.url)
 
             let files: [Path]
             if path.isDirectory {
@@ -110,7 +111,8 @@ extension CLI {
             }
 
             for file in files {
-                if try rewriter.rewrite(fileAt: file.url) { changed += 1 }
+//                if try rewriter.rewrite(fileAt: file.url) { changed += 1 }
+                if try stringsRewriter.rewrite(fileAt: file.url) { changed += 1 }
             }
 
             print("Rewrote \(changed) files")

--- a/Sources/SUR/CLI.swift
+++ b/Sources/SUR/CLI.swift
@@ -7,7 +7,7 @@ import SURCore
 @main
 struct CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        subcommands: [RewriteRImage.self],
+        subcommands: [RewriteCLI.self],
         defaultSubcommand: CLI.self
     )
     @Option(name: .shortAndLong, help: "Root path of your Xcode project. Default is current.", transform: { Path($0) })
@@ -84,53 +84,5 @@ struct RuntimeError: Error, CustomStringConvertible {
     
     init(_ description: String) {
         self.description = description.red.bold
-    }
-}
-
-extension CLI {
-    struct RewriteRImage: ParsableCommand {
-        static let configuration = CommandConfiguration(commandName: "rewrite-r-image", abstract: "Rewrite R.image.<id>()! to UIImage(resource: .<id>)")
-
-        @Option(name: .shortAndLong, help: "Path to folder or file to rewrite. Default is current.", transform: { Path($0) })
-        var path: Path = Path(".")
-
-        func validate() throws {
-            guard path.exists else { throw RuntimeError("Path does not exist") }
-        }
-
-        func run() throws {
-            var changed = 0
-            let rewriter = RToGeneratedAssetsRewriter()
-            let stringsRewriter = RToGeneratedStringsRewriter(projectAt: path.url)
-
-            let files: [Path]
-            if path.isDirectory {
-                files = try collectSwiftFiles(in: path)
-            } else {
-                files = path.extension == "swift" ? [path] : []
-            }
-
-            for file in files {
-//                if try rewriter.rewrite(fileAt: file.url) { changed += 1 }
-                if try stringsRewriter.rewrite(fileAt: file.url) { changed += 1 }
-            }
-
-            print("Rewrote \(changed) files")
-        }
-
-        private func collectSwiftFiles(in root: Path) throws -> [Path] {
-            let skipDirs: Set<String> = [".build", ".git", ".swiftpm", "DerivedData", "Carthage", "Pods"]
-            var result: [Path] = []
-
-            for child in try root.children() {
-                if child.isDirectory {
-                    if skipDirs.contains(child.lastComponent) { continue }
-                    result.append(contentsOf: try collectSwiftFiles(in: child))
-                } else if child.extension == "swift" {
-                    result.append(child)
-                }
-            }
-            return result
-        }
     }
 }

--- a/Sources/SUR/RewriteCLI.swift
+++ b/Sources/SUR/RewriteCLI.swift
@@ -1,0 +1,104 @@
+//
+//  RewriteCLI.swift
+//  SUR
+//
+//  Created by Aleksandr Chernousov on 25/09/2025.
+//
+
+import Foundation
+import ArgumentParser
+import PathKit
+import Rainbow
+
+@main
+struct RewriteCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "sur-rewrite",
+        abstract: "Rewrite R.swift usage to generated localization symbols",
+        version: "1.0.0"
+    )
+    
+    @Argument(help: "Path to the Xcode project (.xcodeproj)")
+    var projectPath: String
+    
+    @Option(name: .shortAndLong, help: "Source root path (default: project directory)")
+    var sourceRoot: String?
+    
+    @Option(name: .shortAndLong, help: "Target name to process (default: all targets)")
+    var target: String?
+    
+    @Flag(name: .shortAndLong, help: "Show detailed warnings and progress")
+    var verbose: Bool = false
+    
+    @Flag(name: .long, help: "Dry run - show what would be changed without writing")
+    var dryRun: Bool = false
+    
+    @Flag(name: .long, help: "Rewrite strings localization")
+    var strings: Bool = false
+    
+    @Flag(name: .long, help: "Rewrite assets")
+    var assets: Bool = false
+    
+    @Option(help: "Paths to exclude from rewriting")
+    var exclude: [String] = []
+    
+    mutating func run() async throws {
+        let projectPath = Path(self.projectPath)
+        let sourceRoot = Path(self.sourceRoot ?? projectPath.parent().string)
+        
+        // Validate project path
+        guard projectPath.exists else {
+            throw ValidationError("Project path does not exist: \(projectPath)")
+        }
+        
+        guard projectPath.extension == "xcodeproj" else {
+            throw ValidationError("Path must be an Xcode project (.xcodeproj): \(projectPath)")
+        }
+        
+        // Determine which rewriters to use
+        var rewriterTypes: Set<RewriteExplorer.RewriterType> = []
+        
+        if strings {
+            rewriterTypes.insert(.strings)
+        }
+        
+        if assets {
+            rewriterTypes.insert(.assets)
+        }
+        
+        // If no specific rewriters are specified, use all
+        if rewriterTypes.isEmpty {
+            rewriterTypes = [.strings, .assets]
+        }
+        
+        // Convert excluded paths
+        let excludedSources = exclude.map { Path($0) }
+        
+        // Create explorer and run
+        let explorer = RewriteExplorer(
+            projectPath: projectPath,
+            sourceRoot: sourceRoot,
+            target: target,
+            showWarnings: verbose,
+            excludedSources: excludedSources,
+            dryRun: dryRun
+        )
+        
+        if dryRun {
+            print("🔍 Dry run mode - no files will be modified".yellow.bold)
+        }
+        
+        print("🚀 Starting rewrite process...".bold)
+        print("   📂 Project: \(projectPath.lastComponent)")
+        print("   📍 Source root: \(sourceRoot)")
+        print("   🔧 Rewriters: \(rewriterTypes.map(\.description).joined(separator: ", "))")
+        
+        try await explorer.explore(rewriterTypes: rewriterTypes)
+    }
+}
+
+extension ValidationError: LocalizedError {
+    public var errorDescription: String? {
+        return message
+    }
+}

--- a/Sources/SUR/RewriteCLI.swift
+++ b/Sources/SUR/RewriteCLI.swift
@@ -9,8 +9,8 @@ import Foundation
 import ArgumentParser
 import PathKit
 import Rainbow
+import SURCore
 
-@main
 struct RewriteCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "sur-rewrite",
@@ -97,7 +97,7 @@ struct RewriteCLI: AsyncParsableCommand {
     }
 }
 
-extension ValidationError: LocalizedError {
+extension ValidationError: @retroactive LocalizedError {
     public var errorDescription: String? {
         return message
     }

--- a/Sources/SUR/RewriteCLI.swift
+++ b/Sources/SUR/RewriteCLI.swift
@@ -13,9 +13,8 @@ import SURCore
 
 struct RewriteCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        commandName: "sur-rewrite",
-        abstract: "Rewrite R.swift usage to generated localization symbols",
-        version: "1.0.0"
+        commandName: "r-to-xcode",
+        abstract: "Rewrite R.swift usage to generated localization symbols"
     )
     
     @Argument(help: "Path to the Xcode project (.xcodeproj)")

--- a/Sources/SURCore/Explorer.swift
+++ b/Sources/SURCore/Explorer.swift
@@ -55,7 +55,7 @@ public final class Explorer {
         print("🦒 Complete".bold)
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     private func analyze() async throws {
         let exploredResources = await storage.exploredResources
         let exploredUsages = await storage.exploredUsages

--- a/Sources/SURCore/Parsers/SwiftVisitors/FuncCallVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/FuncCallVisitor.swift
@@ -9,7 +9,7 @@ final class FuncCallVisitor: SyntaxVisitor {
     
     private(set) var usages: [ExploreUsage] = []
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     init(
         viewMode: SyntaxTreeViewMode = .sourceAccurate,
         _ url: URL,
@@ -162,7 +162,7 @@ final class FuncCallVisitor: SyntaxVisitor {
     }
     
     override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-        return .skipChildren
+        .skipChildren
     }
 }
 

--- a/Sources/SURCore/Parsers/SwiftVisitors/StringVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/StringVisitor.swift
@@ -13,7 +13,7 @@ final class StringVisitor: SyntaxVisitor {
     }
     
     func parse() -> String {
-        return value
+        value
     }
     
     override func visit(_ node: StringSegmentSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -113,7 +113,7 @@ private extension RToGeneratedAssetsRewriter {
             // Standalone member uses: R.<kind>.<id> -> <ResourceType>Resource.<id>
             if let (kind, identifier) = matchRKindIdentifier(from: node) {
                 // Create replacement expression: <ResourceType>Resource.<id>
-                return parseExpr(kind.resource(with: identifier.withoutImageAndColor()))
+                return .parse(kind.resource(with: identifier.withoutImageAndColor()))
                     .with(\.leadingTrivia, node.leadingTrivia)
                     .with(\.trailingTrivia, node.trailingTrivia)
             }
@@ -202,9 +202,8 @@ private extension RToGeneratedAssetsRewriter.Rewriter {
     private func expr(for kind: Kind, with identifier: String, from module: Module) -> ExprSyntax {
         changedModules.insert(module)
         let resource = kind.resource(for: module, with: identifier.withoutImageAndColor())
-        return parseExpr(resource)
+        return .parse(resource)
     }
-        
     
     private func replaceCall(_ call: FunctionCallExprSyntax) -> ExprSyntax? {
         // Ensure no arguments in the call `()`
@@ -235,23 +234,6 @@ private extension RToGeneratedAssetsRewriter.Rewriter {
         }
 
         return nil
-    }
-
-    private func stripSuffix(_ name: String, _ suffix: String) -> String {
-        let lower = name.lowercased()
-        if lower.hasSuffix(suffix), name.count > suffix.count {
-            return String(name.dropLast(suffix.count))
-        }
-        return name
-    }
-
-    private func parseExpr(_ text: String) -> ExprSyntax {
-        // Parse a tiny source text as expression: we wrap it in a dummy file
-        let file = Parser.parse(source: text)
-        if let item = file.statements.first?.item.as(ExprSyntax.self) {
-            return item
-        }
-        return ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(text)))
     }
 }
 

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -42,7 +42,7 @@ public struct RToGeneratedAssetsRewriter: FileRewriter {
             try newText.write(to: url, atomically: true, encoding: .utf8)
         }
         
-        return false
+        return true
     }
 }
 

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -180,7 +180,6 @@ private extension RToGeneratedAssetsRewriter.Rewriter {
         let resource = kind.resource(for: module, with: identifier.withoutImageAndColor())
         return .parse(resource)
     }
-    
 }
 
 private enum Kind: String {

--- a/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedAssetsRewriter.swift
@@ -2,13 +2,13 @@ import Foundation
 import SwiftParser
 import SwiftSyntax
 
-public struct RToGeneratedAssetsRewriter: Sendable {
+public struct RToGeneratedAssetsRewriter: FileRewriter {
     public init() {}
-
+    
     /// Rewrites the given Swift source file in-place.
     /// - Returns: true if the file changed.
     @discardableResult
-    public func rewrite(fileAt url: URL) throws -> Bool {
+    public func rewrite(fileAt url: URL, dryRun: Bool) throws -> Bool {
         let original = try String(contentsOf: url)
         let source = Parser.parse(source: original)
         let rewriter = Rewriter()
@@ -33,10 +33,13 @@ public struct RToGeneratedAssetsRewriter: Sendable {
         }
 
         let newText = transformed.description
-
-        if newText != original {
+        
+        guard newText != original else {
+            return false
+        }
+        
+        if !dryRun {
             try newText.write(to: url, atomically: true, encoding: .utf8)
-            return true
         }
         
         return false

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -91,26 +91,28 @@ private extension RToGeneratedStringsRewriter {
         }
         
         override func visit(_ node: OptionalChainingExprSyntax) -> ExprSyntax {
-            // Handle optional chaining around calls to R.string or text()
-            if let wrappedCall = node.expression.as(FunctionCallExprSyntax.self) {
-                let rewrittenCall = visit(wrappedCall)
-                if rewrittenCall != ExprSyntax(wrappedCall) {
-                    // Return rewritten call without optional chaining, preserving trivia
-                    return applyTrivia(from: node, to: rewrittenCall)
-                }
+            // Handle optional chaining around R.string calls
+            // Since String(localized:) and Text() don't return optionals, ? can be safely removed
+            let rewrittenExpression = visit(node.expression)
+            
+            if rewrittenExpression != node.expression {
+                // R.string was transformed, remove optional chaining and preserve trivia
+                return applyTrivia(from: node, to: rewrittenExpression)
             }
+            
             return super.visit(node)
         }
         
         override func visit(_ node: ForceUnwrapExprSyntax) -> ExprSyntax {
-            // Handle force unwrap around calls to R.string or text()
-            if let wrappedCall = node.expression.as(FunctionCallExprSyntax.self) {
-                let rewrittenCall = visit(wrappedCall)
-                if rewrittenCall != ExprSyntax(wrappedCall) {
-                    // Return rewritten call without force unwrap, preserving trivia
-                    return applyTrivia(from: node, to: rewrittenCall)
-                }
+            // Handle force unwrap around R.string calls  
+            // Since String(localized:) and Text() don't return optionals, ! can be safely removed
+            let rewrittenExpression = visit(node.expression)
+            
+            if rewrittenExpression != node.expression {
+                // R.string was transformed, remove force unwrap and preserve trivia
+                return applyTrivia(from: node, to: rewrittenExpression)
             }
+            
             return super.visit(node)
         }
     }

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -81,7 +81,7 @@ private extension RToGeneratedStringsRewriter {
                     argsText = "(" + node.arguments.description.trimmingCharacters(in: .whitespacesAndNewlines) + ")"
                 }
                 let qualifier = (catalog == "Localizable") ? "" : "\(catalog)."
-                var replacement = ExprSyntax.parse("String(localized: .\(qualifier)\(identifier)\(argsText).with(locale: Locale(languageCode: \(language))))")
+                var replacement = ExprSyntax.parse("String(localized: .\(qualifier)\(identifier)\(argsText).with(preferredLanguages: \(language)))")
                 replacement = applyTrivia(from: node, to: replacement)
                 return replacement
             }
@@ -147,13 +147,13 @@ private extension RToGeneratedStringsRewriter.Rewriter {
         guard
             let call = baseExpr.as(FunctionCallExprSyntax.self),
             let calledMember = call.calledExpression.as(MemberAccessExprSyntax.self),
-            let rBaseMember = calledMember.base?.as(MemberAccessExprSyntax.self),
-            let rDecl = rBaseMember.base?.as(DeclReferenceExprSyntax.self),
+            let rDecl = calledMember.base?.as(DeclReferenceExprSyntax.self),
             rDecl.baseName.text == "R",
             calledMember.declName.baseName.text == "string"
         else {
             return nil
         }
+        
         // Find preferredLanguages argument
         guard let arg = call.arguments.first(where: { $0.label?.text == "preferredLanguages" }) else {
             return nil

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -264,39 +264,20 @@ private extension RToGeneratedStringsRewriter.Rewriter {
         return "(" + arguments.description.trimmingCharacters(in: .whitespacesAndNewlines) + ")"
     }
     
+    /// Applies leading and trailing trivia (whitespace, comments, etc.) from the original syntax node to the new expression.
+    /// This preserves the formatting and comments from the original code in the rewritten expression.
+    ///
+    /// - Parameters:
+    ///   - original: The original syntax node to copy trivia from
+    ///   - expr: The new expression to apply trivia to
+    /// - Returns: The expression with applied trivia
     private func applyTrivia(
         from original: some SyntaxProtocol,
         to expr: ExprSyntax
     ) -> ExprSyntax {
-        let leading = original.leadingTrivia
-        let trailing = original.trailingTrivia
-        
-        if var call = expr.as(FunctionCallExprSyntax.self) {
-            call = call
-                .with(\.leadingTrivia, leading)
-                .with(\.trailingTrivia, trailing)
-            
-            return ExprSyntax(call)
-        }
-        
-        if var member = expr.as(MemberAccessExprSyntax.self) {
-            member = member
-                .with(\.leadingTrivia, leading)
-                .with(\.trailingTrivia, trailing)
-            
-            return ExprSyntax(member)
-        }
-        
-        if var declRef = expr.as(DeclReferenceExprSyntax.self) {
-            declRef = declRef
-                .with(\.leadingTrivia, leading)
-                .with(\.trailingTrivia, trailing)
-            
-            return ExprSyntax(declRef)
-        }
-        
-        // Fallback: return as-is if we can't set trivia
-        return expr
+        expr
+            .with(\.leadingTrivia, original.leadingTrivia)
+            .with(\.trailingTrivia, original.trailingTrivia)
     }
 }
 

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -12,6 +12,11 @@ public struct RToGeneratedStringsRewriter: Sendable {
     
     @discardableResult
     public func rewrite(fileAt fileURL: URL) throws -> Bool {
+        return try rewrite(fileAt: fileURL, dryRun: false)
+    }
+    
+    @discardableResult
+    public func rewrite(fileAt fileURL: URL, dryRun: Bool) throws -> Bool {
         let original = try String(contentsOf: fileURL)
         let sourceFile = Parser.parse(source: original)
         
@@ -26,7 +31,11 @@ public struct RToGeneratedStringsRewriter: Sendable {
         guard rewrittenString != original else {
             return false
         }
-        try rewrittenString.write(to: fileURL, atomically: true, encoding: .utf8)
+        
+        if !dryRun {
+            try rewrittenString.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        
         return true
     }
 }

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -1,0 +1,229 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+
+public struct RToGeneratedStringsRewriter: Sendable {
+    private let catalogs: Set<String>
+    
+    public init(projectAt projectURL: URL) {
+        catalogs = {
+            guard let enumerator = FileManager.default.enumerator(at: projectURL, includingPropertiesForKeys: nil)
+            else { return [] }
+            var catalogs = Set<String>()
+            for case let fileURL as URL in enumerator {
+                if fileURL.pathExtension == "xcstrings" {
+                    catalogs.insert(fileURL.deletingPathExtension().lastPathComponent.lowercased())
+                }
+            }
+            return catalogs
+        }()
+        
+        print("Catalogs found: \(catalogs)")
+    }
+    
+    @discardableResult
+    public func rewrite(fileAt fileURL: URL) throws -> Bool {
+        let original = try String(contentsOf: fileURL)
+        let sourceFile = Parser.parse(source: original)
+        
+        let rewriter = Rewriter(xcstringCatalogs: catalogs)
+        var rewritten = rewriter.visit(sourceFile)
+        
+        if rewriter.usedSwiftUI && !hasImport(named: "SwiftUI", in: rewritten) {
+            rewritten = insertImport(named: "SwiftUI", into: rewritten)
+        }
+        
+        let rewrittenString = rewritten.description
+        guard rewrittenString != original else {
+            return false
+        }
+        try rewrittenString.write(to: fileURL, atomically: true, encoding: .utf8)
+        return true
+    }
+}
+
+private extension RToGeneratedStringsRewriter {
+    final class Rewriter: SyntaxRewriter {
+        let catalogs: Set<String>
+        private(set) var usedSwiftUI = false
+        
+        init(xcstringCatalogs: Set<String>) {
+            self.catalogs = xcstringCatalogs
+            super.init()
+        }
+        
+        override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+            if let calledExpr = node.calledExpression.as(MemberAccessExprSyntax.self) {
+                if
+                    calledExpr.declName.baseName.text == "text",
+                    let baseMember = calledExpr.base?.as(MemberAccessExprSyntax.self),
+                    let (catalog, identifier) = matchRStringCatalogIdentifier(from: baseMember)
+                {
+                    if node.arguments.isEmpty {
+                        usedSwiftUI = true
+                        var replacement = ExprSyntax.parse("Text(.\(catalog).\(identifier))")
+                        replacement = applyTrivia(from: node, to: replacement)
+                        return replacement
+                    }
+                }
+            }
+            
+            if
+                let calledExpr = node.calledExpression.as(MemberAccessExprSyntax.self),
+                let (catalog, identifier) = matchRStringCatalogIdentifier(from: calledExpr)
+            {
+                if node.arguments.isEmpty {
+                    var replacement = ExprSyntax.parse("String(localized: .\(catalog).\(identifier))")
+                    replacement = applyTrivia(from: node, to: replacement)
+                    return replacement
+                }
+            }
+            return super.visit(node)
+        }
+        
+        override func visit(_ node: OptionalChainingExprSyntax) -> ExprSyntax {
+            // Handle optional chaining around calls to R.string or text()
+            if let wrappedCall = node.expression.as(FunctionCallExprSyntax.self) {
+                let rewrittenCall = visit(wrappedCall)
+                if rewrittenCall != ExprSyntax(wrappedCall) {
+                    // Return rewritten call without optional chaining, preserving trivia
+                    let withTrivia = applyTrivia(from: node, to: rewrittenCall)
+                    return withTrivia
+                }
+            }
+            return super.visit(node)
+        }
+        
+        override func visit(_ node: ForceUnwrapExprSyntax) -> ExprSyntax {
+            // Handle force unwrap around calls to R.string or text()
+            if let wrappedCall = node.expression.as(FunctionCallExprSyntax.self) {
+                let rewrittenCall = visit(wrappedCall)
+                if rewrittenCall != ExprSyntax(wrappedCall) {
+                    // Return rewritten call without force unwrap, preserving trivia
+                    let withTrivia = applyTrivia(from: node, to: rewrittenCall)
+                    return withTrivia
+                }
+            }
+            return super.visit(node)
+        }
+    }
+}
+
+private extension RToGeneratedStringsRewriter.Rewriter {
+    func matchRStringCatalogIdentifier(from member: MemberAccessExprSyntax) -> (catalog: String, identifier: String)? {
+        // Expect member like: R.string.<catalog>.<identifier>
+        guard
+            let mid = member.base?.as(MemberAccessExprSyntax.self),
+            let base = mid.base?.as(MemberAccessExprSyntax.self),
+            let declRef = base.base?.as(DeclReferenceExprSyntax.self),
+            declRef.baseName.text == "R",
+            base.declName.baseName.text == "string"
+        else {
+            return nil
+        }
+        
+        let catalog = mid.declName.baseName.text
+        let identifier = member.declName.baseName.text
+        
+        if !catalogs.contains(catalog.lowercased()) {
+            return nil
+        }
+        
+        print("Matched R.string.\(catalog).\(identifier)")
+        
+        return (catalog.capitalizedFirstLetter(), identifier)
+    }
+    
+    private func applyTrivia(from original: some SyntaxProtocol, to expr: ExprSyntax) -> ExprSyntax {
+        let leading = original.leadingTrivia
+        let trailing = original.trailingTrivia
+        
+        if var call = expr.as(FunctionCallExprSyntax.self) {
+            call = call
+                .with(\.leadingTrivia, leading)
+                .with(\.trailingTrivia, trailing)
+            
+            return ExprSyntax(call)
+        }
+        if var member = expr.as(MemberAccessExprSyntax.self) {
+            member = member
+                .with(\.leadingTrivia, leading)
+                .with(\.trailingTrivia, trailing)
+            
+            return ExprSyntax(member)
+        }
+        if var declRef = expr.as(DeclReferenceExprSyntax.self) {
+            declRef = declRef
+                .with(\.leadingTrivia, leading)
+                .with(\.trailingTrivia, trailing)
+            
+            return ExprSyntax(declRef)
+        }
+        // Fallback: return as-is if we can't set trivia
+        return expr
+    }
+}
+
+// MARK: - Import Helpers
+func hasImport(named module: String, in file: SourceFileSyntax) -> Bool {
+    for item in file.statements {
+        if let imp = item.item.as(ImportDeclSyntax.self) {
+            if imp.path.description == module { return true }
+        }
+    }
+    return false
+}
+
+func insertImport(named module: String, into file: SourceFileSyntax) -> SourceFileSyntax {
+    // Build an import decl item by parsing text to keep formatting correct.
+    let parsed = Parser.parse(source: "import \(module)\n")
+    guard var importItem = parsed.statements.first else { return file }
+    
+    let insertIndex = lastImportInsertionIndex(in: file)
+    
+    // If inserting after an existing statement and that statement doesn't end
+    // with a newline, ensure the new import starts on a new line.
+    if insertIndex > 0 {
+        let prev = file.statements[file.statements.index(file.statements.startIndex, offsetBy: insertIndex - 1)]
+        if !triviaEndsWithNewline(prev.trailingTrivia) {
+            importItem = importItem.with(\.leadingTrivia, .newlines(1))
+        }
+    }
+    
+    let newStatements = file.statements.inserting(importItem, at: insertIndex)
+    return file.with(\.statements, newStatements)
+}
+
+func lastImportInsertionIndex(in file: SourceFileSyntax) -> Int {
+    var insertIndex = 0
+    var lastImportIndex: Int?
+    for (i, item) in file.statements.enumerated() where item.item.is(ImportDeclSyntax.self) {
+        lastImportIndex = i
+    }
+    if let idx = lastImportIndex { insertIndex = idx + 1 }
+    return insertIndex
+}
+
+func triviaEndsWithNewline(_ trivia: Trivia?) -> Bool {
+    guard let trivia else { return false }
+    for piece in trivia.reversed() {
+        switch piece {
+        case .newlines(let n): return n > 0
+        case .carriageReturns(let n): return n > 0
+        case .carriageReturnLineFeeds(let n): return n > 0
+        case .spaces, .tabs, .verticalTabs, .formfeeds: continue
+        default: return false
+        }
+    }
+    return false
+}
+
+private extension String {
+    func capitalizedFirstLetter() -> String {
+        guard let first else {
+            return self
+        }
+        
+        return String(first).uppercased() + dropFirst()
+    }
+}

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -2,17 +2,17 @@ import Foundation
 import SwiftParser
 import SwiftSyntax
 
-public struct RToGeneratedStringsRewriter: Sendable {
+public struct RToGeneratedStringsRewriter: FileRewriter {
     private let catalogs: Set<String>
     
-    public init(projectAt projectURL: URL) {
-        catalogs = Self.findXCStringsCatalogs(in: projectURL)
-        print("Catalogs found: \(catalogs)")
+    public init(stringCatalogs: Set<String>) {
+        self.catalogs = stringCatalogs
+        print("Using provided catalogs: \(catalogs)")
     }
     
     @discardableResult
     public func rewrite(fileAt fileURL: URL) throws -> Bool {
-        return try rewrite(fileAt: fileURL, dryRun: false)
+        try rewrite(fileAt: fileURL, dryRun: false)
     }
     
     @discardableResult
@@ -37,19 +37,6 @@ public struct RToGeneratedStringsRewriter: Sendable {
         }
         
         return true
-    }
-}
-
-private extension RToGeneratedStringsRewriter {
-    static func findXCStringsCatalogs(in projectURL: URL) -> Set<String> {
-        guard let enumerator = FileManager.default.enumerator(at: projectURL, includingPropertiesForKeys: nil)
-        else { return [] }
-        
-        var catalogs = Set<String>()
-        for case let fileURL as URL in enumerator where fileURL.pathExtension == "xcstrings" {
-            catalogs.insert(fileURL.deletingPathExtension().lastPathComponent.lowercased())
-        }
-        return catalogs
     }
 }
 

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -72,11 +72,17 @@ private extension RToGeneratedStringsRewriter {
                 let calledExpr = node.calledExpression.as(MemberAccessExprSyntax.self),
                 let (catalog, identifier) = matchRStringCatalogIdentifier(from: calledExpr)
             {
+                // Build replacement preserving any existing arguments, e.g.
+                // R.string.<catalog>.<key>(args...) -> String(localized: .<catalog>.<key>(args...))
+                let argsText: String
                 if node.arguments.isEmpty {
-                    var replacement = ExprSyntax.parse("String(localized: .\(catalog).\(identifier))")
-                    replacement = applyTrivia(from: node, to: replacement)
-                    return replacement
+                    argsText = ""
+                } else {
+                    argsText = "(" + node.arguments.description.trimmingCharacters(in: .whitespacesAndNewlines) + ")"
                 }
+                var replacement = ExprSyntax.parse("String(localized: .\(catalog).\(identifier)\(argsText))")
+                replacement = applyTrivia(from: node, to: replacement)
+                return replacement
             }
             return super.visit(node)
         }

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftParser
 import SwiftSyntax
-import Foundation
 
 public struct RToGeneratedStringsRewriter: Sendable {
     private let catalogs: Set<String>
@@ -62,7 +61,8 @@ private extension RToGeneratedStringsRewriter {
                 {
                     if node.arguments.isEmpty {
                         usedSwiftUI = true
-                        var replacement = ExprSyntax.parse("Text(.\(catalog).\(identifier))")
+                        let qualifier = (catalog == "Localizable") ? "" : "\(catalog)."
+                        var replacement = ExprSyntax.parse("Text(.\(qualifier)\(identifier))")
                         replacement = applyTrivia(from: node, to: replacement)
                         return replacement
                     }
@@ -80,7 +80,8 @@ private extension RToGeneratedStringsRewriter {
                 } else {
                     argsText = "(" + node.arguments.description.trimmingCharacters(in: .whitespacesAndNewlines) + ")"
                 }
-                var replacement = ExprSyntax.parse("String(localized: .\(catalog).\(identifier)\(argsText).with(locale: Locale(languageCode: \(language))))")
+                let qualifier = (catalog == "Localizable") ? "" : "\(catalog)."
+                var replacement = ExprSyntax.parse("String(localized: .\(qualifier)\(identifier)\(argsText).with(locale: Locale(languageCode: \(language))))")
                 replacement = applyTrivia(from: node, to: replacement)
                 return replacement
             }
@@ -97,7 +98,8 @@ private extension RToGeneratedStringsRewriter {
                 } else {
                     argsText = "(" + node.arguments.description.trimmingCharacters(in: .whitespacesAndNewlines) + ")"
                 }
-                var replacement = ExprSyntax.parse("String(localized: .\(catalog).\(identifier)\(argsText))")
+                let qualifier = (catalog == "Localizable") ? "" : "\(catalog)."
+                var replacement = ExprSyntax.parse("String(localized: .\(qualifier)\(identifier)\(argsText))")
                 replacement = applyTrivia(from: node, to: replacement)
                 return replacement
             }

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -142,7 +142,6 @@ private extension RToGeneratedStringsRewriter.Rewriter {
             let arg = call.arguments.first(where: { $0.label?.text == "preferredLanguages" })
         {
             let languageExpr = arg.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-            print("Matched R.string(preferredLanguages: ...).\(catalog).\(identifier)")
             return (catalog.capitalizedFirstLetter(), identifier, languageExpr)
         }
         
@@ -153,7 +152,6 @@ private extension RToGeneratedStringsRewriter.Rewriter {
             declRef.baseName.text == "R",
             base.declName.baseName.text == "string"
         {
-            print("Matched R.string.\(catalog).\(identifier)")
             return (catalog.capitalizedFirstLetter(), identifier, nil)
         }
         

--- a/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
+++ b/Sources/SURCore/Rewriters/RToGeneratedStringsRewriter.swift
@@ -7,7 +7,6 @@ public struct RToGeneratedStringsRewriter: FileRewriter {
     
     public init(stringCatalogs: Set<String>) {
         self.catalogs = stringCatalogs
-        print("Using provided catalogs: \(catalogs)")
     }
     
     @discardableResult

--- a/Sources/SURCore/Rewriters/RewriteExplorer.swift
+++ b/Sources/SURCore/Rewriters/RewriteExplorer.swift
@@ -1,0 +1,230 @@
+//
+//  RewriteExplorer.swift
+//  SUR
+//
+//  Created by Aleksandr Chernousov on 25/09/2025.
+//
+
+import Foundation
+import Glob
+import PathKit
+import Rainbow
+import XcodeProj
+
+/// Discovers and processes files for rewriting R.swift usage to generated localization symbols
+public final class RewriteExplorer {
+    private let projectPath: Path
+    private let sourceRoot: Path
+    private let target: String?
+    private let showWarnings: Bool
+    private let excludedSources: [Path]
+    private let dryRun: Bool
+    
+    /// Supported rewriter types
+    public enum RewriterType {
+        case strings
+        case assets
+    }
+    
+    public init(
+        projectPath: Path,
+        sourceRoot: Path,
+        target: String? = nil,
+        showWarnings: Bool = false,
+        excludedSources: [Path] = [],
+        dryRun: Bool = false
+    ) {
+        self.projectPath = projectPath
+        self.sourceRoot = sourceRoot
+        self.target = target
+        self.showWarnings = showWarnings
+        self.excludedSources = excludedSources
+        self.dryRun = dryRun
+    }
+    
+    /// Explore and rewrite files in the project
+    public func explore(rewriterTypes: Set<RewriterType> = [.strings, .assets]) async throws {
+        print("🔨 Loading project \(projectPath.lastComponent) for rewriting".bold)
+        let xcodeproj = try XcodeProj(path: projectPath)
+        
+        for target in xcodeproj.pbxproj.nativeTargets {
+            if self.target == nil || (self.target != nil && target.name == self.target) {
+                print("📦 Processing target \(target.name) for rewriting".bold)
+                try await explore(target: target, rewriterTypes: rewriterTypes)
+            }
+        }
+        
+        print("✨ Rewriting complete".bold.green)
+    }
+    
+    private func explore(target: PBXNativeTarget, rewriterTypes: Set<RewriterType>) async throws {
+        // Process sources
+        if let sources = try target.sourcesBuildPhase() {
+            try await explore(sources: sources, rewriterTypes: rewriterTypes)
+        }
+        
+        // Process synchronized groups (modern Xcode projects)
+        if let synchronizedGroups = target.fileSystemSynchronizedGroups {
+            try await explore(groups: synchronizedGroups, rewriterTypes: rewriterTypes)
+        }
+    }
+    
+    private func explore(groups: [PBXFileSystemSynchronizedRootGroup], rewriterTypes: Set<RewriterType>) async throws {
+        for group in groups {
+            guard let path = try group.fullPath(sourceRoot: sourceRoot) else {
+                continue
+            }
+            
+            // Find all Swift files in the group
+            let sources = Glob(pattern: path.string + "**/*.swift")
+                .map { Path($0) }
+                .filter { !excludedSources.contains($0) }
+            
+            try await explore(files: sources, rewriterTypes: rewriterTypes)
+        }
+    }
+    
+    private func explore(sources: PBXSourcesBuildPhase, rewriterTypes: Set<RewriterType>) async throws {
+        guard let files = sources.files else {
+            throw RewriteError.notFound(message: "Source files not found")
+        }
+        
+        let paths = try files
+            .compactMap { try $0.file?.fullPath(sourceRoot: sourceRoot) }
+            .filter { $0.extension == "swift" }
+            .filter { !excludedSources.contains($0) }
+        
+        try await explore(files: paths, rewriterTypes: rewriterTypes)
+    }
+    
+    private func explore(files: some Sequence<Path>, rewriterTypes: Set<RewriterType>) async throws {
+        let rewriteResults = try await withThrowingTaskGroup(of: RewriteResult.self) { group in
+            files.forEach { path in
+                group.addTask { @Sendable [projectPath, dryRun, showWarnings] in
+                    try await self.rewriteFile(
+                        at: path,
+                        projectPath: projectPath,
+                        rewriterTypes: rewriterTypes,
+                        dryRun: dryRun,
+                        showWarnings: showWarnings
+                    )
+                }
+            }
+            
+            return try await group.reduce(into: [], { $0.append($1) })
+        }
+        
+        // Report results
+        await reportResults(rewriteResults)
+    }
+    
+    private func rewriteFile(
+        at path: Path,
+        projectPath: Path,
+        rewriterTypes: Set<RewriterType>,
+        dryRun: Bool,
+        showWarnings: Bool
+    ) async throws -> RewriteResult {
+        var changes: [RewriterType: Bool] = [:]
+        var errors: [RewriterType: Error] = [:]
+        
+        for rewriterType in rewriterTypes {
+            do {
+                let rewriter = try createRewriter(type: rewriterType, projectPath: projectPath)
+                let hasChanges = try rewriter.rewrite(fileAt: path.url, dryRun: dryRun)
+                changes[rewriterType] = hasChanges
+                
+                if hasChanges && showWarnings {
+                    print("✏️  Rewritten \(rewriterType): \(path.relativePath)")
+                }
+            } catch {
+                errors[rewriterType] = error
+                if showWarnings {
+                    print("❌ Error rewriting \(path.relativePath) with \(rewriterType): \(error)")
+                }
+            }
+        }
+        
+        return RewriteResult(path: path, changes: changes, errors: errors)
+    }
+    
+    private func createRewriter(type: RewriterType, projectPath: Path) throws -> any FileRewriter {
+        switch type {
+        case .strings:
+            return RToGeneratedStringsRewriter(projectAt: projectPath.url)
+        case .assets:
+            return RToGeneratedAssetsRewriter(projectAt: projectPath.url)
+        }
+    }
+    
+    private func reportResults(_ results: [RewriteResult]) async {
+        let totalFiles = results.count
+        let modifiedFiles = results.filter { !$0.changes.isEmpty && $0.changes.values.contains(true) }
+        let errorFiles = results.filter { !$0.errors.isEmpty }
+        
+        print("\n📊 Rewrite Summary:".bold)
+        print("   📁 Total files processed: \(totalFiles)")
+        print("   ✅ Modified files: \(modifiedFiles.count)")
+        print("   ❌ Files with errors: \(errorFiles.count)")
+        
+        if !modifiedFiles.isEmpty {
+            print("\n📝 Modified files:".yellow.bold)
+            for result in modifiedFiles {
+                let changedTypes = result.changes.compactMap { type, changed in
+                    changed ? type.description : nil
+                }.joined(separator: ", ")
+                print("   • \(result.path.relativePath) (\(changedTypes))")
+            }
+        }
+        
+        if !errorFiles.isEmpty {
+            print("\n🚨 Files with errors:".red.bold)
+            for result in errorFiles {
+                print("   • \(result.path.relativePath)")
+                for (type, error) in result.errors {
+                    print("     └─ \(type): \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Supporting Types
+
+/// Protocol for file rewriters
+public protocol FileRewriter {
+    init(projectAt projectURL: URL) throws
+    func rewrite(fileAt fileURL: URL, dryRun: Bool) throws -> Bool
+}
+
+/// Result of rewriting a single file
+struct RewriteResult {
+    let path: Path
+    let changes: [RewriteExplorer.RewriterType: Bool]
+    let errors: [RewriteExplorer.RewriterType: Error]
+}
+
+/// Errors that can occur during rewriting
+enum RewriteError: Error {
+    case notFound(message: String)
+    case rewriteFailed(message: String)
+}
+
+// MARK: - Extensions
+
+extension RewriteExplorer.RewriterType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .strings: return "strings"
+        case .assets: return "assets"
+        }
+    }
+}
+
+extension RToGeneratedStringsRewriter: FileRewriter {
+    // FileRewriter conformance is provided by the dryRun method we added
+}
+
+extension RToGeneratedAssetsRewriter: FileRewriter {
+    // FileRewriter conformance would need to be added to RToGeneratedAssetsRewriter
+}

--- a/Sources/SURCore/Rewriters/RewriteExplorer.swift
+++ b/Sources/SURCore/Rewriters/RewriteExplorer.swift
@@ -176,7 +176,7 @@ public struct RewriteExplorer: Sendable {
                 }
                 .joined(separator: ", ")
                 
-                print("   • \(result.path) (\(changedTypes))")
+                print("   • \(result.path.lastComponent) (\(changedTypes))")
             }
         }
         
@@ -189,6 +189,8 @@ public struct RewriteExplorer: Sendable {
                 }
             }
         }
+        
+        print("")
     }
 }
 

--- a/Sources/SURCore/Utils/ExprSyntax+parse.swift
+++ b/Sources/SURCore/Utils/ExprSyntax+parse.swift
@@ -1,0 +1,22 @@
+//
+//  ExprSyntax+parse.swift
+//  SUR
+//
+//  Created by Alexander Chernousov on 16.09.2025.
+//
+
+import SwiftParser
+import SwiftSyntax
+
+extension ExprSyntax {
+    static func parse(_ text: String) -> ExprSyntax {
+        // Parse a tiny source text as expression: we wrap it in a dummy file
+        let file = Parser.parse(source: text)
+        
+        if let item = file.statements.first?.item.as(ExprSyntax.self) {
+            return item
+        }
+        
+        return ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(text)))
+    }
+}

--- a/Sources/SURCore/Utils/ImportHelpers.swift
+++ b/Sources/SURCore/Utils/ImportHelpers.swift
@@ -39,8 +39,11 @@ enum ImportHelpers {
             }
         }
         
-        let newStatements = file.statements.inserting(importItem, at: insertIndex)
-        return file.with(\.statements, newStatements)
+        // Create new statements array by inserting the import at the correct position
+        var newStatements = Array(file.statements)
+        newStatements.insert(importItem, at: insertIndex)
+        let newStatementsCollection = CodeBlockItemListSyntax(newStatements)
+        return file.with(\.statements, newStatementsCollection)
     }
     
     static func lastImportInsertionIndex(in file: SourceFileSyntax) -> Int {

--- a/Sources/SURCore/Utils/ImportHelpers.swift
+++ b/Sources/SURCore/Utils/ImportHelpers.swift
@@ -1,0 +1,72 @@
+//
+//  ImportHelpers.swift
+//  SUR
+//
+//  Created by Aleksandr Chernousov on 25/09/2025.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftParser
+
+enum ImportHelpers {
+    static func hasImport(named module: String, in file: SourceFileSyntax) -> Bool {
+        for item in file.statements {
+            if let imp = item.item.as(ImportDeclSyntax.self) {
+                if imp.path.description == module {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+    
+    static func insertImport(named module: String, into file: SourceFileSyntax) -> SourceFileSyntax {
+        // Build an import decl item by parsing text to keep formatting correct.
+        let parsed = Parser.parse(source: "import \(module)\n")
+        guard var importItem = parsed.statements.first else {
+            return file
+        }
+        
+        let insertIndex = lastImportInsertionIndex(in: file)
+        
+        // If inserting after an existing statement and that statement doesn't end
+        // with a newline, ensure the new import starts on a new line.
+        if insertIndex > 0 {
+            let prev = file.statements[file.statements.index(file.statements.startIndex, offsetBy: insertIndex - 1)]
+            if !triviaEndsWithNewline(prev.trailingTrivia) {
+                importItem = importItem.with(\.leadingTrivia, .newlines(1))
+            }
+        }
+        
+        let newStatements = file.statements.inserting(importItem, at: insertIndex)
+        return file.with(\.statements, newStatements)
+    }
+    
+    static func lastImportInsertionIndex(in file: SourceFileSyntax) -> Int {
+        var insertIndex = 0
+        var lastImportIndex: Int?
+        for (i, item) in file.statements.enumerated() where item.item.is(ImportDeclSyntax.self) {
+            lastImportIndex = i
+        }
+        if let idx = lastImportIndex { insertIndex = idx + 1 }
+        return insertIndex
+    }
+
+    static func triviaEndsWithNewline(_ trivia: Trivia?) -> Bool {
+        guard let trivia else {
+            return false
+        }
+        
+        for piece in trivia.reversed() {
+            switch piece {
+            case .newlines(let n): return n > 0
+            case .carriageReturns(let n): return n > 0
+            case .carriageReturnLineFeeds(let n): return n > 0
+            case .spaces, .tabs, .verticalTabs, .formfeeds: continue
+            default: return false
+            }
+        }
+        return false
+    }
+}

--- a/Sources/SURCore/Utils/ImportHelpers.swift
+++ b/Sources/SURCore/Utils/ImportHelpers.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 
 enum ImportHelpers {
     static func hasImport(named module: String, in file: SourceFileSyntax) -> Bool {

--- a/Sources/SURCore/Utils/Path+Utils.swift
+++ b/Sources/SURCore/Utils/Path+Utils.swift
@@ -16,7 +16,10 @@ extension Path {
         }
         else {
             // Skip hidden files
-            if lastComponent.hasPrefix(".") { return 0 }
+            if lastComponent.hasPrefix(".") {
+                return 0
+            }
+            
             let attr = try? FileManager.default.attributesOfItem(atPath: absolute().string)
             if let num = attr?[.size] as? NSNumber {
                 return num.intValue

--- a/Sources/SURCore/Utils/String+Utils.swift
+++ b/Sources/SURCore/Utils/String+Utils.swift
@@ -9,8 +9,6 @@ import Foundation
 
 extension String {
     func count(of needle: Character) -> Int {
-        return reduce(0) {
-            $1 == needle ? $0 + 1 : $0
-        }
+        reduce(0) { $1 == needle ? $0 + 1 : $0 }
     }
 }


### PR DESCRIPTION
This pull request refactors and extends the CLI for rewriting R.swift usages and improves code modularity, linting, and rewriting logic. The most important changes are the replacement of the old CLI command with a more configurable `RewriteCLI`, improvements to the file rewriter interface and import handling, and a significant update to SwiftLint rules and configuration.

### CLI Refactor and Extension
* Replaced the old `RewriteRImage` CLI command with a new `RewriteCLI` in `Sources/SUR/CLI.swift`, supporting more options (project path, source root, target, asset/string selection, exclusion, dry run, verbosity). The new command is implemented in `Sources/SUR/RewriteCLI.swift`. [[1]](diffhunk://#diff-201b209e37d9480808e013bebe4b11de5c67d58369d1d4be1ec896d332122f57L10-R10) [[2]](diffhunk://#diff-201b209e37d9480808e013bebe4b11de5c67d58369d1d4be1ec896d332122f57L89-L134) [[3]](diffhunk://#diff-e64524b831d90e56774ecdd69d297366f92b98c8980ac8b5a929d20d003d9a54R1-R103)

### File Rewriter Improvements
* Refactored `RToGeneratedAssetsRewriter` to conform to a new `FileRewriter` protocol, added support for dry-run mode, and moved import detection/insertion logic to a dedicated `ImportHelpers` utility for better separation of concerns. [[1]](diffhunk://#diff-2c83d7b743a43d6e2ab40ac485a59403911599cf845ce4c1ac5601c8784e7022L5-R11) [[2]](diffhunk://#diff-2c83d7b743a43d6e2ab40ac485a59403911599cf845ce4c1ac5601c8784e7022L20-R50) [[3]](diffhunk://#diff-2c83d7b743a43d6e2ab40ac485a59403911599cf845ce4c1ac5601c8784e7022L126-L180)

### SwiftLint Configuration Updates
* Added and removed several opt-in lint rules for better code quality, and restructured configuration for rule severities, length limits, and naming conventions in `.swiftlint.yml`. [[1]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fR19) [[2]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fR34-R35) [[3]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fR64) [[4]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fR76) [[5]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fL140) [[6]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fL150) [[7]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fR172-R259)

### Code Quality and Syntax Improvements
* Simplified code by removing redundant return statements and improving syntax in visitor classes and rewriters. [[1]](diffhunk://#diff-46c004e5bf0b1ab810036e0daad4531501f8ce332a8670abd65f07af09c58359L165-R165) [[2]](diffhunk://#diff-c54c48c3f0425a80f2247db67cd943457070df5b2509f727283eb17d2970070dL16-R16) [[3]](diffhunk://#diff-2c83d7b743a43d6e2ab40ac485a59403911599cf845ce4c1ac5601c8784e7022L116-R119) [[4]](diffhunk://#diff-2c83d7b743a43d6e2ab40ac485a59403911599cf845ce4c1ac5601c8784e7022L240-R184)

### SwiftLint Disable Directives
* Updated SwiftLint disable comments to only disable `cyclomatic_complexity` where needed, removing unnecessary disables for `function_body_length`. [[1]](diffhunk://#diff-658e86db31d7e034ac1af893a9ccc2e9963f50c774f3307740e14ac249427ac4L58-R58) [[2]](diffhunk://#diff-46c004e5bf0b1ab810036e0daad4531501f8ce332a8670abd65f07af09c58359L12-R12)