### PR TITLE
Update Swift package dependencies and tools version

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -150,7 +150,7 @@ opt_in_rules:
   # - no_magic_numbers
   - private_action
   - private_outlet
-  - redundant_self_in_closure
+  - redundant_self
   - sorted_imports
   - strict_fileprivate
   - strong_iboutlet

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "e23ef4d86072fb1443eb593b08519839c11d3c1c1b078dfd01b7c5dee6184be7",
+  "originHash" : "39b4c125a061151921b03e3f7edb859ab17337914c88f2804a6b869783da84b6",
   "pins" : [
     {
       "identity" : "aexml",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tadija/AEXML.git",
       "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Rainbow.git",
       "state" : {
-        "revision" : "e0dada9cd44e3fa7ec3b867e49a8ddbf543e3df3",
-        "version" : "4.0.1"
+        "revision" : "16da5c62dd737258c6df2e8c430f8a3202f655a7",
+        "version" : "4.2.0"
       }
     },
     {
@@ -60,17 +60,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
-        "version" : "1.5.0"
+        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
+        "version" : "1.6.1"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "7c80ce6f142164b0201871e580b021d1b2c69804",
-        "version" : "0.57.0"
+        "revision" : "6166499ede0efe43c3809f101d2c3cd409e2b77a",
+        "version" : "0.61.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "85265f385fd4d22e366a856f1ee0e1ecf3298a51",
-        "version" : "8.24.9"
+        "revision" : "e1f2a4365669e02272b2f381b13a2378b15fb485",
+        "version" : "9.5.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
-        "version" : "5.1.3"
+        "revision" : "d41ba4e7164c0838c6d48351f7575f7f762151fe",
+        "version" : "6.1.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "39b4c125a061151921b03e3f7edb859ab17337914c88f2804a6b869783da84b6",
+  "originHash" : "ca440ea861a3ad6be08659fe9a16ef46c0f5e82a9e73a4c7b4ee0da9d7800d84",
   "pins" : [
     {
       "identity" : "aexml",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Rainbow.git",
       "state" : {
-        "revision" : "16da5c62dd737258c6df2e8c430f8a3202f655a7",
-        "version" : "4.2.0"
+        "revision" : "cdf146ae671b2624917648b61c908d1244b98ca1",
+        "version" : "4.2.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "6166499ede0efe43c3809f101d2c3cd409e2b77a",
-        "version" : "0.61.0"
+        "revision" : "707f7face5524fe918f82dd39c5c80cb3e591a44",
+        "version" : "0.63.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "e1f2a4365669e02272b2f381b13a2378b15fb485",
-        "version" : "9.5.0"
+        "revision" : "31712ec42e9cbc46e7fd25ea55c2730cb3476097",
+        "version" : "9.7.2"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "d41ba4e7164c0838c6d48351f7575f7f762151fe",
-        "version" : "6.1.0"
+        "revision" : "51b5127c7fb6ffac106ad6d199aaa33c5024895f",
+        "version" : "6.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,19 +14,19 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
         .package(url: "https://github.com/Bouke/Glob.git", from: "1.0.5"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", from: "9.5.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", from: "9.7.2"),
         .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.6.1"),
-        .package(url: "https://github.com/onevcat/Rainbow.git", from: "4.2.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.1"),
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins.git", from: "0.61.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "6.1.0")
+        .package(url: "https://github.com/onevcat/Rainbow.git", from: "4.2.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0"),
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins.git", from: "0.63.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.0")
     ],
     targets: [
         .executableTarget(
             name: "SUR",
             dependencies: [
-                "PathKit",
-                "Rainbow",
+                .product(name: "PathKit", package: "PathKit"),
+                .product(name: "Rainbow", package: "Rainbow"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .target(name: "SURCore"),
             ],
@@ -44,11 +44,11 @@ let package = Package(
         .target(
             name: "SURCore",
             dependencies:[
-                "PathKit",
-                "Glob",
-                "XcodeProj",
-                "IBDecodable",
-                "Rainbow",
+                .product(name: "PathKit", package: "PathKit"),
+                .product(name: "Glob", package: "Glob"),
+                .product(name: "XcodeProj", package: "XcodeProj"),
+                .product(name: "IBDecodable", package: "IBDecodable"),
+                .product(name: "Rainbow", package: "Rainbow"),
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftParser", package: "swift-syntax"),
                 .product(name: "Yams", package: "Yams"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 
 import PackageDescription
 
@@ -11,15 +11,15 @@ let package = Package(
         .library(name: "SURCore", targets: ["SURCore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax", from: "600.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
         .package(url: "https://github.com/Bouke/Glob.git", from: "1.0.5"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", from: "8.23.7"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", from: "9.5.0"),
         .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.6.1"),
-        .package(url: "https://github.com/onevcat/Rainbow.git", from: "4.0.1"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.57.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.3")
+        .package(url: "https://github.com/onevcat/Rainbow.git", from: "4.2.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.1"),
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins.git", from: "0.61.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "6.1.0")
     ],
     targets: [
         .executableTarget(

--- a/Sources/SURCore/Items/Explore/ExploreResource.swift
+++ b/Sources/SURCore/Items/Explore/ExploreResource.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import PathKit
 
 struct ExploreResource: Sendable {
     let name: String


### PR DESCRIPTION
This pull request updates the Swift package configuration to support newer toolchain and dependency versions. The main focus is on upgrading the Swift tools version and several package dependencies to ensure compatibility and access to new features.

Toolchain update:

* Upgraded the Swift tools version in `Package.swift` from 6.0 to 6.2 to support the latest Swift language features and improvements.

Dependency upgrades:

* Updated the `swift-syntax` dependency to use the `swiftlang/swift-syntax.git` repository and increased the minimum version from 600.0.0 to 602.0.0.
* Increased the minimum version for `XcodeProj` from 8.23.7 to 9.5.0.
* Bumped the `Rainbow` dependency from 4.0.1 to 4.2.0.
* Updated `swift-argument-parser` from 1.5.0 to 1.6.1 and switched to the `.git` repository URL.
* Upgraded `SwiftLintPlugins` from 0.57.0 to 0.61.0 and switched to the `.git` repository URL.
* Increased the minimum version for `Yams` from 5.1.3 to 6.1.0.