### PR TITLE
Use sourceRoot for string catalog discovery

### DIFF
--- a/Sources/SURCore/Rewriters/RewriteExplorer.swift
+++ b/Sources/SURCore/Rewriters/RewriteExplorer.swift
@@ -37,7 +37,7 @@ public struct RewriteExplorer: Sendable {
         self.dryRun = dryRun
         
         // Find string catalogs once during initialization
-        self.stringCatalogs = Self.findXCStringsCatalogs(in: projectPath.url)
+        self.stringCatalogs = Self.findXCStringsCatalogs(in: sourceRoot.url)
         
         if showWarnings && !stringCatalogs.isEmpty {
             print("📚 Found string catalogs: \(stringCatalogs.joined(separator: ", "))")


### PR DESCRIPTION
Changed string catalog search to use sourceRoot.url instead of projectPath.url during RewriteExplorer initialization. This ensures catalogs are found relative to the source root, improving accuracy.