### PR TITLE
Skip directories with 'icon' extension in Explorer

### DIFF
--- a/Sources/SURCore/Explorer.swift
+++ b/Sources/SURCore/Explorer.swift
@@ -198,6 +198,10 @@ public final class Explorer {
             throw ExploreError.notFound(message: "Could not get full path for resource \(resource) (uuid: \(resource.uuid))")
         }
         
+        if fullPath.containsDirectory(withExtension: "icon") {
+            return
+        }
+        
         try await explore(resource: fullPath)
     }
     

--- a/Sources/SURCore/Explorer.swift
+++ b/Sources/SURCore/Explorer.swift
@@ -176,8 +176,13 @@ public final class Explorer {
                     if ext != "xcassets" && resource.contains("xcassets") {
                         continue
                     }
+
+                    let resourcePath = Path(resource)
+                    if resourcePath.containsDirectory(withExtension: "icon") {
+                        continue
+                    }
                     
-                    try await explore(resource: Path(resource))
+                    try await explore(resource: resourcePath)
                 }
             }
             
@@ -260,6 +265,7 @@ public final class Explorer {
         
         let resources = Glob(pattern: path.string + kind.assets)
             .map { Path($0) }
+            .filter { !$0.containsDirectory(withExtension: "icon") }
             .map {
                 ExploreResource(
                     name: $0.lastComponentWithoutExtension,

--- a/Sources/SURCore/Utils/Path+Utils.swift
+++ b/Sources/SURCore/Utils/Path+Utils.swift
@@ -31,12 +31,19 @@ extension Path {
     }
 
     func containsDirectory(withExtension ext: String) -> Bool {
+        // Normalize the target extension: remove leading dot(s) and lowercase
+        let normalizedExt = ext.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
+
         let directoryComponents = NSString(string: string)
             .pathComponents
             .dropLast()
 
         return directoryComponents.contains { component in
-            Path(component).extension == ext
+            let componentExt = Path(component).extension?
+                .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+                .lowercased()
+
+            return componentExt == normalizedExt
         }
     }
 }

--- a/Sources/SURCore/Utils/Path+Utils.swift
+++ b/Sources/SURCore/Utils/Path+Utils.swift
@@ -29,4 +29,14 @@ extension Path {
             }
         }
     }
+
+    func containsDirectory(withExtension ext: String) -> Bool {
+        let directoryComponents = NSString(string: string)
+            .pathComponents
+            .dropLast()
+
+        return directoryComponents.contains { component in
+            Path(component).extension == ext
+        }
+    }
 }


### PR DESCRIPTION
Add Path.containsDirectory(withExtension:) utility and update Explorer to ignore resources that reside inside directories whose extension is "icon". This prevents exploring/including .icon-style directories when walking resources and when globbing assets by filtering them out before exploration.