### PR TITLE
Enhance resource usage detection and add comprehensive tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,5 +65,14 @@ let package = Package(
             url: "https://github.com/mugabe/SwiftUnusedResources/releases/download/0.2.0/sur-0.2.0.artifactbundle.zip",
             checksum: "e9b9a14acc466bcec39f43cea85993d2698b6503f212fb0e3805c4fd1636ff3a"
         ),
+        .testTarget(
+            name: "SURCoreTests",
+            dependencies: [
+                .target(name: "SURCore"),
+            ],
+            plugins: skipSwiftLint ? [] : [
+                 .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")
+            ]
+        ),
     ]
 )

--- a/Sources/SURCore/Items/Explore/ExploreKind.swift
+++ b/Sources/SURCore/Items/Explore/ExploreKind.swift
@@ -26,4 +26,11 @@ extension ExploreKind {
         case .color: "Color"
         }
     }
+
+    var resourceClassName: String {
+        switch self {
+        case .image: "ImageResource"
+        case .color: "ColorResource"
+        }
+    }
 }

--- a/Sources/SURCore/Items/Explore/ExploreUsage.swift
+++ b/Sources/SURCore/Items/Explore/ExploreUsage.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ExploreUsage: Sendable {
+enum ExploreUsage: Sendable, Equatable {
     case string(_ value: String, _ kind: ExploreKind)
     case regexp(_ pattern: String, _ kind: ExploreKind)
     case rswift(_ identifier: String, _ kind: ExploreKind)

--- a/Sources/SURCore/Parsers/SwiftParser.swift
+++ b/Sources/SURCore/Parsers/SwiftParser.swift
@@ -15,9 +15,16 @@ struct SwiftParser: Sendable {
         _ path: URL
     ) throws -> [ExploreUsage] {
         let file = try String(contentsOf: path)
-        let source = Parser.parse(source: file)
-        let visitor = SourceVisitor(showWarnings: showWarnings, kinds: kinds, path, source)
-        
+        return parse(source: file, at: path)
+    }
+
+    func parse(
+        source: String,
+        at path: URL = URL(fileURLWithPath: "<source>")
+    ) -> [ExploreUsage] {
+        let tree = Parser.parse(source: source)
+        let visitor = SourceVisitor(showWarnings: showWarnings, kinds: kinds, path, tree)
+
         return visitor.usages
     }
 }

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+NestedVisitors.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+NestedVisitors.swift
@@ -1,0 +1,90 @@
+import SwiftSyntax
+
+extension SourceVisitor {
+    final class MemberVisitor: SyntaxVisitor {
+        private(set) var members: [String] = []
+
+        override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+            members.append(node.baseName.text)
+
+            return super.visit(node)
+        }
+    }
+
+    /// Collects the expressions of all `return` statements within the visited subtree,
+    /// skipping nested scopes (closures, functions, subscripts, nested types) so their
+    /// returns are not attributed to the enclosing declaration.
+    final class ReturnVisitor: SyntaxVisitor {
+        private(set) var expressions: [ExprSyntax] = []
+
+        override func visit(_ node: ReturnStmtSyntax) -> SyntaxVisitorContinueKind {
+            if let expression = node.expression {
+                expressions.append(expression)
+            }
+
+            return .visitChildren
+        }
+
+        override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+    }
+
+    /// Collects the names of bare member accesses (member accesses with no base, e.g. `.assetName`).
+    /// Skips children once a bare member is found so the innermost member of a chain is recorded once.
+    final class BareMemberVisitor: SyntaxVisitor {
+        private(set) var names: [String] = []
+
+        override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+            guard node.base == nil else {
+                return .visitChildren
+            }
+
+            names.append(node.declName.baseName.text)
+
+            return .skipChildren
+        }
+
+        override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+            // Only the called expression can be part of the value (e.g. `.asset.resized()`);
+            // arguments are unrelated expressions and must not be harvested as bare members.
+            walk(node.calledExpression)
+
+            return .skipChildren
+        }
+
+        override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
+            walk(node.calledExpression)
+
+            return .skipChildren
+        }
+    }
+}

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+NestedVisitors.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+NestedVisitors.swift
@@ -60,6 +60,11 @@ extension SourceVisitor {
 
     /// Collects the names of bare member accesses (member accesses with no base, e.g. `.assetName`).
     /// Skips children once a bare member is found so the innermost member of a chain is recorded once.
+    ///
+    /// Function-call arguments are intentionally walked, not skipped: wrapper constructors such as
+    /// `Optional.some(.asset)` / `Optional(.asset)` carry the real resource inside the argument, and
+    /// missing it would be a false negative — far worse for an unused-resource tool (it could lead to
+    /// deleting an actually-used asset) than the harmless over-collection of an unrelated argument.
     final class BareMemberVisitor: SyntaxVisitor {
         private(set) var names: [String] = []
 
@@ -69,20 +74,6 @@ extension SourceVisitor {
             }
 
             names.append(node.declName.baseName.text)
-
-            return .skipChildren
-        }
-
-        override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-            // Only the called expression can be part of the value (e.g. `.asset.resized()`);
-            // arguments are unrelated expressions and must not be harvested as bare members.
-            walk(node.calledExpression)
-
-            return .skipChildren
-        }
-
-        override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
-            walk(node.calledExpression)
 
             return .skipChildren
         }

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
@@ -9,7 +9,12 @@ final class SourceVisitor: SyntaxVisitor {
     private var hasSwiftUI = false
     
     private(set) var usages: [ExploreUsage] = []
-    private var typedLocals: [String: ExploreKind] = [:]
+
+    /// Lexical scope stack of resource-typed variables, used to attribute assignments
+    /// (`local = .asset`) to the right kind. The root scope holds file/type-level names;
+    /// a new scope is pushed per function-like / type body so a local in one scope does
+    /// not leak into same-named variables elsewhere.
+    private var scopes: [[String: ExploreKind]] = [[:]]
 
     @discardableResult
     init(
@@ -82,7 +87,7 @@ final class SourceVisitor: SyntaxVisitor {
             }
 
             if let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
-                typedLocals[name] = kind
+                declareTypedVariable(name, kind)
             }
 
             if let value = binding.initializer?.value {
@@ -98,6 +103,8 @@ final class SourceVisitor: SyntaxVisitor {
     }
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+
         if let kind = typedKind(for: node.signature.returnClause?.type), let body = node.body {
             collectReturnedAssets(in: body.statements, with: kind)
         }
@@ -105,12 +112,22 @@ final class SourceVisitor: SyntaxVisitor {
         return .visitChildren
     }
 
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        popScope()
+    }
+
     override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+
         if let kind = typedKind(for: node.signature?.returnClause?.type) {
             collectReturnedAssets(in: node.statements, with: kind)
         }
 
         return .visitChildren
+    }
+
+    override func visitPost(_ node: ClosureExprSyntax) {
+        popScope()
     }
 
     override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
@@ -120,7 +137,7 @@ final class SourceVisitor: SyntaxVisitor {
             elements.count >= 3,
             elements[1].is(AssignmentExprSyntax.self),
             let lhs = elements.first?.as(DeclReferenceExprSyntax.self),
-            let kind = typedLocals[lhs.baseName.text]
+            let kind = resolveTypedVariable(lhs.baseName.text)
         else {
             return .visitChildren
         }
@@ -135,6 +152,69 @@ final class SourceVisitor: SyntaxVisitor {
         }
 
         return .visitChildren
+    }
+
+    override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: InitializerDeclSyntax) {
+        popScope()
+    }
+
+    override func visit(_ node: AccessorDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: AccessorDeclSyntax) {
+        popScope()
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ClassDeclSyntax) {
+        popScope()
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: StructDeclSyntax) {
+        popScope()
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: EnumDeclSyntax) {
+        popScope()
+    }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ActorDeclSyntax) {
+        popScope()
+    }
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ExtensionDeclSyntax) {
+        popScope()
     }
 }
 
@@ -200,6 +280,33 @@ extension SourceVisitor {
         visitor.walk(usage)
 
         return visitor.members
+    }
+
+    private func pushScope() {
+        scopes.append([:])
+    }
+
+    private func popScope() {
+        if scopes.count > 1 {
+            scopes.removeLast()
+        }
+    }
+
+    /// Records a resource-typed variable in the current (innermost) scope.
+    private func declareTypedVariable(_ name: String, _ kind: ExploreKind) {
+        scopes[scopes.count - 1][name] = kind
+    }
+
+    /// Looks a variable up from the innermost scope outwards, so a local shadows
+    /// an enclosing declaration and names do not leak between sibling scopes.
+    private func resolveTypedVariable(_ name: String) -> ExploreKind? {
+        for scope in scopes.reversed() {
+            if let kind = scope[name] {
+                return kind
+            }
+        }
+
+        return nil
     }
 
     /// Resolves a type annotation/return clause to the resource kind it refers to,
@@ -439,6 +546,20 @@ private extension SourceVisitor {
             }
 
             names.append(node.declName.baseName.text)
+
+            return .skipChildren
+        }
+
+        override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+            // Only the called expression can be part of the value (e.g. `.asset.resized()`);
+            // arguments are unrelated expressions and must not be harvested as bare members.
+            walk(node.calledExpression)
+
+            return .skipChildren
+        }
+
+        override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
+            walk(node.calledExpression)
 
             return .skipChildren
         }

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
@@ -64,14 +64,54 @@ final class SourceVisitor: SyntaxVisitor {
     override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
         let newUsages = kinds
             .compactMap { findR(in: node, with: $0) ?? findGeneratedAsset(in: node, with: $0) }
-        
+
         guard !newUsages.isEmpty else {
             return .visitChildren
         }
-        
+
         usages.append(contentsOf: newUsages)
-        
+
         return .skipChildren
+    }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        for binding in node.bindings {
+            guard let kind = typedKind(for: binding.typeAnnotation?.type) else {
+                continue
+            }
+
+            if let value = binding.initializer?.value {
+                collectBareMembers(in: value, with: kind)
+            }
+
+            if let statements = getterStatements(of: binding.accessorBlock) {
+                for expression in returnPositionExpressions(in: statements) {
+                    collectBareMembers(in: expression, with: kind)
+                }
+            }
+        }
+
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        if let kind = typedKind(for: node.signature.returnClause?.type), let body = node.body {
+            for expression in returnPositionExpressions(in: body.statements) {
+                collectBareMembers(in: expression, with: kind)
+            }
+        }
+
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        if let kind = typedKind(for: node.signature?.returnClause?.type) {
+            for expression in returnPositionExpressions(in: node.statements) {
+                collectBareMembers(in: expression, with: kind)
+            }
+        }
+
+        return .visitChildren
     }
 }
 
@@ -97,7 +137,7 @@ extension SourceVisitor {
         in node: DeclReferenceExprSyntax,
         with kind: ExploreKind
     ) -> ExploreUsage? {
-        guard [kind.uiClassName, kind.swiftUIClassName].contains(node.baseName.text) else {
+        guard [kind.uiClassName, kind.swiftUIClassName, kind.resourceClassName].contains(node.baseName.text) else {
             return nil
         }
         
@@ -133,10 +173,88 @@ extension SourceVisitor {
         }
         
         let visitor = MemberVisitor(viewMode: viewMode)
-        
+
         visitor.walk(usage)
-        
+
         return visitor.members
+    }
+
+    /// Resolves a type annotation/return clause to the resource kind it refers to,
+    /// unwrapping `Optional`, implicitly-unwrapped optionals and `Array` (both sugar and generic forms).
+    private func typedKind(for type: TypeSyntax?) -> ExploreKind? {
+        guard let type else {
+            return nil
+        }
+
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return typedKind(for: optional.wrappedType)
+        }
+
+        if let optional = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return typedKind(for: optional.wrappedType)
+        }
+
+        if let array = type.as(ArrayTypeSyntax.self) {
+            return typedKind(for: array.element)
+        }
+
+        guard let identifier = type.as(IdentifierTypeSyntax.self) else {
+            return nil
+        }
+
+        let name = identifier.name.text
+
+        if name == "Array" || name == "Optional" {
+            if let argument = identifier.genericArgumentClause?.arguments.first?.argument.as(TypeSyntax.self) {
+                return typedKind(for: argument)
+            }
+            return nil
+        }
+
+        let kind = kinds.first { $0.resourceClassName == name }
+
+        return kind
+    }
+
+    /// Returns the statements of a property's `get` accessor, covering both the
+    /// shorthand `{ ... }` getter and an explicit `get { ... }` accessor.
+    private func getterStatements(of accessorBlock: AccessorBlockSyntax?) -> CodeBlockItemListSyntax? {
+        guard let accessorBlock else {
+            return nil
+        }
+
+        switch accessorBlock.accessors {
+        case .getter(let statements):
+            return statements
+
+        case .accessors(let accessors):
+            return accessors
+                .first { $0.accessorSpecifier.tokenKind == .keyword(.get) }?
+                .body?
+                .statements
+        }
+    }
+
+    /// Collects return-position expressions: the single expression of an implicit-return
+    /// body, plus the expression of every `return` statement in the body.
+    private func returnPositionExpressions(in statements: CodeBlockItemListSyntax) -> [ExprSyntax] {
+        if statements.count == 1, let item = statements.first, case .expr(let expression) = item.item {
+            return [expression]
+        }
+
+        let visitor = ReturnVisitor(viewMode: viewMode)
+        statements.forEach { visitor.walk($0) }
+
+        return visitor.expressions
+    }
+
+    /// Records every bare member access (`.assetName`, i.e. with no base) found in `expression`
+    /// as a `.generated` usage. Handles ternary branches, array literals and parentheses.
+    private func collectBareMembers(in expression: some SyntaxProtocol, with kind: ExploreKind) {
+        let visitor = BareMemberVisitor(viewMode: viewMode)
+        visitor.walk(expression)
+
+        usages.append(contentsOf: visitor.names.map { .generated($0, kind) })
     }
 }
 
@@ -153,11 +271,40 @@ private extension ExploreKind {
 private extension SourceVisitor {
     final class MemberVisitor: SyntaxVisitor {
         private(set) var members: [String] = []
-        
+
         override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
             members.append(node.baseName.text)
-            
+
             return super.visit(node)
+        }
+    }
+
+    /// Collects the expressions of all `return` statements within the visited subtree.
+    final class ReturnVisitor: SyntaxVisitor {
+        private(set) var expressions: [ExprSyntax] = []
+
+        override func visit(_ node: ReturnStmtSyntax) -> SyntaxVisitorContinueKind {
+            if let expression = node.expression {
+                expressions.append(expression)
+            }
+
+            return .visitChildren
+        }
+    }
+
+    /// Collects the names of bare member accesses (member accesses with no base, e.g. `.assetName`).
+    /// Skips children once a bare member is found so the innermost member of a chain is recorded once.
+    final class BareMemberVisitor: SyntaxVisitor {
+        private(set) var names: [String] = []
+
+        override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+            guard node.base == nil else {
+                return .visitChildren
+            }
+
+            names.append(node.declName.baseName.text)
+
+            return .skipChildren
         }
     }
 }

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
@@ -9,7 +9,8 @@ final class SourceVisitor: SyntaxVisitor {
     private var hasSwiftUI = false
     
     private(set) var usages: [ExploreUsage] = []
-    
+    private var typedLocals: [String: ExploreKind] = [:]
+
     @discardableResult
     init(
         viewMode: SyntaxTreeViewMode = .sourceAccurate,
@@ -80,14 +81,16 @@ final class SourceVisitor: SyntaxVisitor {
                 continue
             }
 
+            if let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
+                typedLocals[name] = kind
+            }
+
             if let value = binding.initializer?.value {
-                collectBareMembers(in: value, with: kind)
+                collectValue(value, with: kind)
             }
 
             if let statements = getterStatements(of: binding.accessorBlock) {
-                for expression in returnPositionExpressions(in: statements) {
-                    collectBareMembers(in: expression, with: kind)
-                }
+                collectReturnedAssets(in: statements, with: kind)
             }
         }
 
@@ -96,9 +99,7 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         if let kind = typedKind(for: node.signature.returnClause?.type), let body = node.body {
-            for expression in returnPositionExpressions(in: body.statements) {
-                collectBareMembers(in: expression, with: kind)
-            }
+            collectReturnedAssets(in: body.statements, with: kind)
         }
 
         return .visitChildren
@@ -106,9 +107,31 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
         if let kind = typedKind(for: node.signature?.returnClause?.type) {
-            for expression in returnPositionExpressions(in: node.statements) {
-                collectBareMembers(in: expression, with: kind)
-            }
+            collectReturnedAssets(in: node.statements, with: kind)
+        }
+
+        return .visitChildren
+    }
+
+    override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+        let elements = node.elements.array()
+
+        guard
+            elements.count >= 3,
+            elements[1].is(AssignmentExprSyntax.self),
+            let lhs = elements.first?.as(DeclReferenceExprSyntax.self),
+            let kind = typedLocals[lhs.baseName.text]
+        else {
+            return .visitChildren
+        }
+
+        let rhs = Array(elements.dropFirst(2))
+
+        if rhs.count == 1 {
+            collectValue(rhs[0], with: kind)
+        }
+        else {
+            rhs.forEach { collectBareMembers(in: $0, with: kind) }
         }
 
         return .visitChildren
@@ -235,21 +258,100 @@ extension SourceVisitor {
         }
     }
 
-    /// Collects return-position expressions: the single expression of an implicit-return
-    /// body, plus the expression of every `return` statement in the body.
-    private func returnPositionExpressions(in statements: CodeBlockItemListSyntax) -> [ExprSyntax] {
-        if statements.count == 1, let item = statements.first, case .expr(let expression) = item.item {
-            return [expression]
-        }
-
+    /// Collects every asset returned by a body — both explicit `return`s (anywhere in the body,
+    /// excluding nested scopes) and the implicit-return trailing expression — resolving through
+    /// `if` / `switch` / ternary branches without ever touching conditions or `case` patterns.
+    private func collectReturnedAssets(in statements: CodeBlockItemListSyntax, with kind: ExploreKind) {
         let visitor = ReturnVisitor(viewMode: viewMode)
         statements.forEach { visitor.walk($0) }
 
-        return visitor.expressions
+        let leaves = visitor.expressions.flatMap { resolveTail($0) } + implicitTail(of: statements)
+
+        leaves.forEach { collectBareMembers(in: $0, with: kind) }
+    }
+
+    /// Resolves the implicit-return value of a block: if its last item is an expression,
+    /// expand it through control-flow value positions; otherwise nothing.
+    private func implicitTail(of statements: CodeBlockItemListSyntax) -> [ExprSyntax] {
+        guard let last = statements.last, let expression = tailExpression(of: last.item) else {
+            return []
+        }
+
+        return resolveTail(expression)
+    }
+
+    /// The value expression of a trailing code-block item, unwrapping the `ExpressionStmtSyntax`
+    /// that wraps a standalone `if` / `switch` used as an implicit-return expression.
+    private func tailExpression(of item: CodeBlockItemSyntax.Item) -> ExprSyntax? {
+        switch item {
+        case .expr(let expression):
+            return expression
+
+        case .stmt(let statement):
+            return statement.as(ExpressionStmtSyntax.self)?.expression
+
+        default:
+            return nil
+        }
+    }
+
+    /// Expands a value-position expression into the leaf value expressions it may evaluate to,
+    /// descending through ternary / `if` / `switch` expressions (branch results only) and
+    /// unwrapping `try` / `await` / parentheses.
+    private func resolveTail(_ expression: ExprSyntax) -> [ExprSyntax] {
+        if let ternary = expression.as(TernaryExprSyntax.self) {
+            return resolveTail(ternary.thenExpression) + resolveTail(ternary.elseExpression)
+        }
+
+        if let ifExpr = expression.as(IfExprSyntax.self) {
+            return resolveTail(ifExpr)
+        }
+
+        if let switchExpr = expression.as(SwitchExprSyntax.self) {
+            return switchExpr.cases
+                .compactMap { $0.as(SwitchCaseSyntax.self) }
+                .flatMap { implicitTail(of: $0.statements) }
+        }
+
+        if let tryExpr = expression.as(TryExprSyntax.self) {
+            return resolveTail(tryExpr.expression)
+        }
+
+        if let awaitExpr = expression.as(AwaitExprSyntax.self) {
+            return resolveTail(awaitExpr.expression)
+        }
+
+        if let tuple = expression.as(TupleExprSyntax.self), tuple.elements.count == 1, let only = tuple.elements.first {
+            return resolveTail(only.expression)
+        }
+
+        return [expression]
+    }
+
+    private func resolveTail(_ ifExpr: IfExprSyntax) -> [ExprSyntax] {
+        var leaves = implicitTail(of: ifExpr.body.statements)
+
+        switch ifExpr.elseBody {
+        case .codeBlock(let block):
+            leaves += implicitTail(of: block.statements)
+
+        case .ifExpr(let elseIf):
+            leaves += resolveTail(elseIf)
+
+        case nil:
+            break
+        }
+
+        return leaves
+    }
+
+    /// Resolves a value expression (initializer / assignment RHS) and records its bare members.
+    private func collectValue(_ expression: ExprSyntax, with kind: ExploreKind) {
+        resolveTail(expression).forEach { collectBareMembers(in: $0, with: kind) }
     }
 
     /// Records every bare member access (`.assetName`, i.e. with no base) found in `expression`
-    /// as a `.generated` usage. Handles ternary branches, array literals and parentheses.
+    /// as a `.generated` usage. Handles array literals and member chains.
     private func collectBareMembers(in expression: some SyntaxProtocol, with kind: ExploreKind) {
         let visitor = BareMemberVisitor(viewMode: viewMode)
         visitor.walk(expression)
@@ -279,7 +381,9 @@ private extension SourceVisitor {
         }
     }
 
-    /// Collects the expressions of all `return` statements within the visited subtree.
+    /// Collects the expressions of all `return` statements within the visited subtree,
+    /// skipping nested scopes (closures, functions, subscripts, nested types) so their
+    /// returns are not attributed to the enclosing declaration.
     final class ReturnVisitor: SyntaxVisitor {
         private(set) var expressions: [ExprSyntax] = []
 
@@ -289,6 +393,38 @@ private extension SourceVisitor {
             }
 
             return .visitChildren
+        }
+
+        override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
         }
     }
 

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
@@ -136,8 +136,9 @@ final class SourceVisitor: SyntaxVisitor {
         guard
             elements.count >= 3,
             elements[1].is(AssignmentExprSyntax.self),
-            let lhs = elements.first?.as(DeclReferenceExprSyntax.self),
-            let kind = resolveTypedVariable(lhs.baseName.text)
+            let lhs = elements.first,
+            let name = assignmentTargetName(lhs),
+            let kind = resolveTypedVariable(name)
         else {
             return .visitChildren
         }
@@ -309,6 +310,25 @@ extension SourceVisitor {
         return nil
     }
 
+    /// The tracked variable name an assignment targets: a bare `name` or an implicit-self
+    /// `self.name`. Other member-access targets (`other.name`) are ignored, as they refer
+    /// to a different object and would otherwise be misattributed to a same-named local.
+    private func assignmentTargetName(_ expression: ExprSyntax) -> String? {
+        if let declReference = expression.as(DeclReferenceExprSyntax.self) {
+            return declReference.baseName.text
+        }
+
+        guard let member = expression.as(MemberAccessExprSyntax.self) else {
+            return nil
+        }
+
+        if let base = member.base?.as(DeclReferenceExprSyntax.self), base.baseName.text == "self" {
+            return member.declName.baseName.text
+        }
+
+        return nil
+    }
+
     /// Resolves a type annotation/return clause to the resource kind it refers to,
     /// unwrapping `Optional`, implicitly-unwrapped optionals and `Array` (both sugar and generic forms).
     private func typedKind(for type: TypeSyntax?) -> ExploreKind? {
@@ -473,95 +493,6 @@ private extension ExploreKind {
         case "imageLiteral": self = .image
         case "colorLiteral": self = .color
         default: return nil
-        }
-    }
-}
-
-private extension SourceVisitor {
-    final class MemberVisitor: SyntaxVisitor {
-        private(set) var members: [String] = []
-
-        override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
-            members.append(node.baseName.text)
-
-            return super.visit(node)
-        }
-    }
-
-    /// Collects the expressions of all `return` statements within the visited subtree,
-    /// skipping nested scopes (closures, functions, subscripts, nested types) so their
-    /// returns are not attributed to the enclosing declaration.
-    final class ReturnVisitor: SyntaxVisitor {
-        private(set) var expressions: [ExprSyntax] = []
-
-        override func visit(_ node: ReturnStmtSyntax) -> SyntaxVisitorContinueKind {
-            if let expression = node.expression {
-                expressions.append(expression)
-            }
-
-            return .visitChildren
-        }
-
-        override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-
-        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-
-        override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-
-        override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-
-        override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-
-        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-
-        override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-
-        override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
-    }
-
-    /// Collects the names of bare member accesses (member accesses with no base, e.g. `.assetName`).
-    /// Skips children once a bare member is found so the innermost member of a chain is recorded once.
-    final class BareMemberVisitor: SyntaxVisitor {
-        private(set) var names: [String] = []
-
-        override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-            guard node.base == nil else {
-                return .visitChildren
-            }
-
-            names.append(node.declName.baseName.text)
-
-            return .skipChildren
-        }
-
-        override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-            // Only the called expression can be part of the value (e.g. `.asset.resized()`);
-            // arguments are unrelated expressions and must not be harvested as bare members.
-            walk(node.calledExpression)
-
-            return .skipChildren
-        }
-
-        override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
-            walk(node.calledExpression)
-
-            return .skipChildren
         }
     }
 }

--- a/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
+++ b/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
@@ -210,18 +210,31 @@ struct GeneratedResourceUsageTests {
         #expect(Set(ids) == ["placeholder", "foo", "bar"])
     }
 
-    // MARK: - Precision
+    // MARK: - Wrapper constructors
 
-    @Test("Ignores bare members passed as function-call arguments in a resource return")
-    func ignoresCallArguments() {
+    @Test("Detects a resource wrapped in Optional.some(...)")
+    func wrappedInOptionalSome() {
         let source = """
-        func icon(for screen: Screen) -> ImageResource {
-            resolve(for: .settingsScreen)
+        func icon() -> ImageResource? {
+            Optional.some(.star)
         }
         """
         let ids = generatedIdentifiers(source, kind: .image)
-        #expect(ids.isEmpty)
+        #expect(ids == ["star"])
     }
+
+    @Test("Detects a resource wrapped in a bare .some(...) and Optional(...)")
+    func wrappedInBareSomeAndInit() {
+        // The wrapped resource must be captured; over-collecting the `.some` wrapper itself is the
+        // harmless, safe direction (it never causes a used asset to be reported as unused).
+        let someIds = generatedIdentifiers("let icon: ImageResource? = .some(.star)", kind: .image)
+        #expect(someIds.contains("star"))
+
+        let initIds = generatedIdentifiers("let icon: ImageResource? = Optional(.brand)", kind: .image)
+        #expect(initIds == ["brand"])
+    }
+
+    // MARK: - Precision
 
     @Test("Confines resource-typed locals to their own scope")
     func scopedTypedLocals() {

--- a/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
+++ b/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
@@ -254,6 +254,37 @@ struct GeneratedResourceUsageTests {
         #expect(Set(ids) == ["seed", "reassigned"])
     }
 
+    @Test("Detects self-qualified assignment to a resource-typed stored property")
+    func selfQualifiedPropertyAssignment() {
+        let source = """
+        class Library {
+            var icon: ImageResource = .seed
+
+            func update() {
+                self.icon = .reassigned
+            }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["seed", "reassigned"])
+    }
+
+    @Test("Ignores assignment to a same-named property on another object")
+    func ignoresForeignObjectAssignment() {
+        let source = """
+        class Library {
+            var icon: ImageResource = .seed
+
+            func update(other: Other) {
+                other.icon = .foreign
+            }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["seed"])
+        #expect(!ids.contains("foreign"))
+    }
+
     // MARK: - Negative
 
     @Test("Ignores switch over unrelated enum in non-resource context")

--- a/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
+++ b/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+
+@testable import SURCore
+
+@Suite("ImageResource / ColorResource usage detection")
+struct GeneratedResourceUsageTests {
+    private func generatedIdentifiers(
+        _ source: String,
+        kind: ExploreKind
+    ) -> [String] {
+        let parser = SwiftParser(showWarnings: false, kinds: [kind])
+
+        return parser.parse(source: source).compactMap { usage in
+            if case .generated(let identifier, let usageKind) = usage, usageKind == kind {
+                return identifier
+            }
+            return nil
+        }
+    }
+
+    // MARK: - Explicit type-prefixed access
+
+    @Test("Detects ImageResource.assetName")
+    func explicitImageAccess() {
+        let ids = generatedIdentifiers("let value = ImageResource.star", kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    @Test("Detects ColorResource.assetName")
+    func explicitColorAccess() {
+        let ids = generatedIdentifiers("let value = ColorResource.brand", kind: .color)
+        #expect(ids == ["brand"])
+    }
+
+    // MARK: - Type-annotated bindings
+
+    @Test("Detects bare member in type-annotated binding")
+    func annotatedBinding() {
+        let ids = generatedIdentifiers("let icon: ImageResource = .star", kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    @Test("Detects bare members in array-typed binding")
+    func arrayTypedBinding() {
+        let ids = generatedIdentifiers("let icons: [ImageResource] = [.a, .b]", kind: .image)
+        #expect(ids == ["a", "b"])
+    }
+
+    @Test("Detects bare member in optional-typed binding")
+    func optionalTypedBinding() {
+        let ids = generatedIdentifiers("let icon: ImageResource? = .star", kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    // MARK: - Computed properties
+
+    @Test("Detects bare member in computed property")
+    func computedProperty() {
+        let ids = generatedIdentifiers("var icon: ImageResource { .star }", kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    @Test("Detects both ternary branches in computed property")
+    func computedPropertyTernary() {
+        let source = "var badge: ColorResource { flag ? .on : .off }"
+        let ids = generatedIdentifiers(source, kind: .color)
+        #expect(Set(ids) == ["on", "off"])
+    }
+
+    @Test("Detects bare member in explicit get accessor")
+    func explicitGetAccessor() {
+        let source = "var icon: ImageResource { get { .star } }"
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    // MARK: - Function / closure return types
+
+    @Test("Detects bare member in implicit function return")
+    func functionImplicitReturn() {
+        let ids = generatedIdentifiers("func makeIcon() -> ImageResource { .star }", kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    @Test("Detects bare member in explicit function return")
+    func functionExplicitReturn() {
+        let source = "func makeIcon() -> ImageResource { return .star }"
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    @Test("Detects bare member in closure return type")
+    func closureReturnType() {
+        let source = "let make = { () -> ImageResource in .star }"
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    // MARK: - Negative
+
+    @Test("Ignores bare member in non-resource-typed context")
+    func ignoresUnrelatedEnum() {
+        let imageIds = generatedIdentifiers("let value: SomeEnum = .caseA", kind: .image)
+        let colorIds = generatedIdentifiers("let value: SomeEnum = .caseA", kind: .color)
+        #expect(imageIds.isEmpty)
+        #expect(colorIds.isEmpty)
+    }
+
+    // MARK: - Regression: existing detection still works
+
+    @Test("Still detects SwiftUI Image(.assetName)")
+    func swiftUIImageGenerated() {
+        let source = """
+        import SwiftUI
+        let view = Image(.star)
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(ids == ["star"])
+    }
+
+    @Test("Still detects UIImage(resource: .assetName)")
+    func uiKitImageGenerated() {
+        let source = """
+        import UIKit
+        let image = UIImage(resource: .star)
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(ids == ["star"])
+    }
+}

--- a/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
+++ b/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
@@ -210,6 +210,50 @@ struct GeneratedResourceUsageTests {
         #expect(Set(ids) == ["placeholder", "foo", "bar"])
     }
 
+    // MARK: - Precision
+
+    @Test("Ignores bare members passed as function-call arguments in a resource return")
+    func ignoresCallArguments() {
+        let source = """
+        func icon(for screen: Screen) -> ImageResource {
+            resolve(for: .settingsScreen)
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(ids.isEmpty)
+    }
+
+    @Test("Confines resource-typed locals to their own scope")
+    func scopedTypedLocals() {
+        let source = """
+        func a() -> ImageResource {
+            var icon: ImageResource = .home
+            return icon
+        }
+        func b() {
+            icon = .somethingElse
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["home"])
+        #expect(!ids.contains("somethingElse"))
+    }
+
+    @Test("Detects assignment to a resource-typed stored property from a method")
+    func storedPropertyAssignment() {
+        let source = """
+        class Library {
+            var icon: ImageResource = .seed
+
+            func update() {
+                icon = .reassigned
+            }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["seed", "reassigned"])
+    }
+
     // MARK: - Negative
 
     @Test("Ignores switch over unrelated enum in non-resource context")

--- a/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
+++ b/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
@@ -97,7 +97,136 @@ struct GeneratedResourceUsageTests {
         #expect(ids == ["star"])
     }
 
+    // MARK: - Control flow: explicit returns
+
+    @Test("Detects assets returned from switch cases")
+    func switchExplicitReturns() {
+        let source = """
+        func icon(for state: State) -> ImageResource {
+            switch state {
+            case .loading: return .spinner
+            case .done: return .check
+            }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["spinner", "check"])
+    }
+
+    @Test("Detects assets returned from if/else branches")
+    func ifElseExplicitReturns() {
+        let source = """
+        func icon(flag: Bool) -> ImageResource {
+            if flag { return .foo } else { return .bar }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["foo", "bar"])
+    }
+
+    @Test("Detects early return plus trailing return")
+    func earlyAndTrailingReturn() {
+        let source = """
+        func icon(flag: Bool) -> ImageResource {
+            if flag { return .foo }
+            return .bar
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["foo", "bar"])
+    }
+
+    @Test("Detects asset returned from guard else")
+    func guardElseReturn() {
+        let source = """
+        func icon(value: Int?) -> ImageResource {
+            guard value != nil else { return .fallback }
+            return .main
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["fallback", "main"])
+    }
+
+    // MARK: - Control flow: implicit returns (expressions)
+
+    @Test("Detects assets in implicit-return switch expression, ignoring case patterns")
+    func switchImplicitReturn() {
+        let source = """
+        var icon: ImageResource {
+            switch state {
+            case .loading: .spinner
+            case .done: .check
+            }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["spinner", "check"])
+        // Case patterns must not be collected as assets.
+        #expect(!ids.contains("loading"))
+        #expect(!ids.contains("done"))
+    }
+
+    @Test("Detects assets in implicit-return if/else expression")
+    func ifElseImplicitReturn() {
+        let source = """
+        var icon: ImageResource {
+            if flag { .foo } else { .bar }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["foo", "bar"])
+    }
+
+    @Test("Detects assets in if nested inside a switch case")
+    func nestedIfInsideSwitch() {
+        let source = """
+        var icon: ImageResource {
+            switch state {
+            case .a: flag ? .one : .two
+            case .b: .three
+            }
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["one", "two", "three"])
+    }
+
+    // MARK: - Assignment dataflow
+
+    @Test("Detects assets assigned to a resource-typed local across branches")
+    func assignmentDataflow() {
+        let source = """
+        func icon(for state: State) -> ImageResource {
+            var result: ImageResource = .placeholder
+            switch state {
+            case .a: result = .foo
+            default: result = .bar
+            }
+            return result
+        }
+        """
+        let ids = generatedIdentifiers(source, kind: .image)
+        #expect(Set(ids) == ["placeholder", "foo", "bar"])
+    }
+
     // MARK: - Negative
+
+    @Test("Ignores switch over unrelated enum in non-resource context")
+    func ignoresUnrelatedSwitch() {
+        let source = """
+        func describe(_ state: State) -> String {
+            switch state {
+            case .success: "ok"
+            case .failure: "no"
+            }
+        }
+        """
+        let imageIds = generatedIdentifiers(source, kind: .image)
+        let colorIds = generatedIdentifiers(source, kind: .color)
+        #expect(imageIds.isEmpty)
+        #expect(colorIds.isEmpty)
+    }
 
     @Test("Ignores bare member in non-resource-typed context")
     func ignoresUnrelatedEnum() {


### PR DESCRIPTION
This pull request introduces advanced detection of generated resource usages (such as `ImageResource` and `ColorResource`) in Swift code. The main improvements include enhanced dataflow analysis for assignments, computed properties, and control flow, enabling more accurate identification of resource asset usage. Comprehensive tests are also added to validate these scenarios.

**Resource usage detection improvements:**

* Added deep dataflow analysis to track resource usage through variable assignments, computed properties, function/closure returns, and control flow constructs (if, switch, ternary), including both explicit and implicit returns. This enables detection of asset usage in a much wider variety of code patterns. [[1]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R77-R138) [[2]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543L100-R163) [[3]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R204-R360) [[4]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R383-R445)
* Implemented type resolution logic to map type annotations (including optionals, arrays, and generics) to resource kinds, allowing detection of resource usage in type-annotated contexts. [[1]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R204-R360) [[2]](diffhunk://#diff-45236d501048bd99b6c7b101005c2b41c04d608dc4f1643bd37c050177e84457R29-R35)
* Extended detection to include direct references to resource types via the new `resourceClassName` property on `ExploreKind`. [[1]](diffhunk://#diff-45236d501048bd99b6c7b101005c2b41c04d608dc4f1643bd37c050177e84457R29-R35) [[2]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543L100-R163)

**Codebase enhancements:**

* Refactored `SwiftParser` to expose a new `parse(source:at:)` method for easier testing and improved modularity.
* Made `ExploreUsage` conform to `Equatable` to facilitate comparison in tests.

**Testing:**

* Added a comprehensive suite of tests in `SURCoreTests/GeneratedResourceUsageTests.swift`, covering all new detection scenarios, including explicit/implicit returns, computed properties, assignment dataflow, and negative cases.

**Build system:**

* Registered the new test target `SURCoreTests` in `Package.swift` to enable the new test suite.