### PR TITLE
Suppress warnings with sur: skip directive and refactor tests

### DIFF
--- a/Sources/SURCore/Parsers/SwiftVisitors/FuncCallVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/FuncCallVisitor.swift
@@ -52,7 +52,9 @@ final class FuncCallVisitor: SyntaxVisitor {
                 
                 let regex = StringVisitor(tuple).parse()
                 if regex == ".*" {
-                    warn(url: url, node: tuple, "Couldn't guess match, please specify pattern")
+                    if !hasSkipComment(tuple) {
+                        warn(url: url, node: tuple, "Couldn't guess match, please specify pattern")
+                    }
                     return
                 }
 
@@ -84,7 +86,9 @@ final class FuncCallVisitor: SyntaxVisitor {
             let regex = StringVisitor(tuple).parse()
 
             if regex == ".*" {
-                warn(url: url, node: tuple, "Couldn't guess match, please specify pattern")
+                if !hasSkipComment(tuple) {
+                    warn(url: url, node: tuple, "Couldn't guess match, please specify pattern")
+                }
                 return
             }
 
@@ -151,8 +155,46 @@ final class FuncCallVisitor: SyntaxVisitor {
 
             p = p.parent!
         }
-        
+
         return nil
+    }
+
+    private func matchesSkip(text: String) -> Bool {
+        (try? NSRegularExpression(pattern: "^\\s*(?:\\/\\/|\\*+)?\\s*sur:\\s*skip\\s*$"))
+            .map { regex in
+                regex.firstMatch(in: text, options: [], range: NSRange(text.startIndex..., in: text)) != nil
+            } ?? false
+    }
+
+    private func extractSkip(_ trivia: Trivia?) -> Bool {
+        guard let trivia else {
+            return false
+        }
+
+        for piece in trivia {
+            if case .lineComment(let c) = piece, matchesSkip(text: c) {
+                return true
+            }
+            else if case .blockComment(let c) = piece, matchesSkip(text: c) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func hasSkipComment(_ node: SyntaxProtocol) -> Bool {
+        var p: SyntaxProtocol = node
+
+        while p.parent != nil && p.syntaxNodeType != CodeBlockItemSyntax.self {
+            if extractSkip(p.leadingTrivia) || extractSkip(p.trailingTrivia) {
+                return true
+            }
+
+            p = p.parent!
+        }
+
+        return false
     }
     
     override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {

--- a/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
+++ b/Tests/SURCoreTests/GeneratedResourceUsageTests.swift
@@ -12,7 +12,7 @@ struct GeneratedResourceUsageTests {
         let parser = SwiftParser(showWarnings: false, kinds: [kind])
 
         return parser.parse(source: source).compactMap { usage in
-            if case .generated(let identifier, let usageKind) = usage, usageKind == kind {
+            if case let .generated(identifier, usageKind) = usage, usageKind == kind {
                 return identifier
             }
             return nil

--- a/Tests/SURCoreTests/WarningSkipTests.swift
+++ b/Tests/SURCoreTests/WarningSkipTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+@testable import SURCore
+
+@Suite("// sur:skip suppresses the unguessable-pattern warning", .serialized)
+struct WarningSkipTests {
+    /// Parses `source` with warnings enabled and returns everything printed to stdout.
+    private func warnings(for source: String) -> String {
+        let pipe = Pipe()
+        let original = dup(fileno(stdout))
+        fflush(stdout)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, fileno(stdout))
+
+        let parser = SwiftParser(showWarnings: true, kinds: [.image, .color])
+        _ = parser.parse(source: source)
+
+        fflush(stdout)
+        dup2(original, fileno(stdout))
+        close(original)
+        pipe.fileHandleForWriting.closeFile()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    // MARK: - Baseline: warning is emitted without the directive
+
+    @Test("Warns for an unguessable SwiftUI Image")
+    func warnsForSwiftUIImage() {
+        let output = warnings(for: """
+        import SwiftUI
+
+        let view = Image(dynamicName)
+        """)
+
+        #expect(output.contains("Couldn't guess match, please specify pattern"))
+    }
+
+    @Test("Warns for an unguessable UIImage(named:)")
+    func warnsForUIImage() {
+        let output = warnings(for: """
+        import UIKit
+
+        let image = UIImage(named: dynamicName)
+        """)
+
+        #expect(output.contains("Couldn't guess match, please specify pattern"))
+    }
+
+    // MARK: - Suppression with // sur: skip
+
+    @Test("Skips the warning for a SwiftUI Image annotated with // sur: skip")
+    func skipsSwiftUIImage() {
+        let output = warnings(for: """
+        import SwiftUI
+
+        // sur: skip
+        let view = Image(dynamicName)
+        """)
+
+        #expect(output.isEmpty)
+    }
+
+    @Test("Skips the warning for a UIImage(named:) annotated with // sur: skip")
+    func skipsUIImage() {
+        let output = warnings(for: """
+        import UIKit
+
+        // sur: skip
+        let image = UIImage(named: dynamicName)
+        """)
+
+        #expect(output.isEmpty)
+    }
+
+    @Test("Honors the directive in a trailing line comment")
+    func skipsTrailingComment() {
+        let output = warnings(for: """
+        import SwiftUI
+
+        let view = Image(dynamicName) // sur: skip
+        """)
+
+        #expect(output.isEmpty)
+    }
+
+    @Test("Honors the directive without a space after the colon")
+    func skipsWithoutSpace() {
+        let output = warnings(for: """
+        import SwiftUI
+
+        // sur:skip
+        let view = Image(dynamicName)
+        """)
+
+        #expect(output.isEmpty)
+    }
+
+    @Test("Ignores an unrelated comment")
+    func ignoresUnrelatedComment() {
+        let output = warnings(for: """
+        import SwiftUI
+
+        // just a regular comment
+        let view = Image(dynamicName)
+        """)
+
+        #expect(output.contains("Couldn't guess match, please specify pattern"))
+    }
+}


### PR DESCRIPTION
This pull request introduces support for suppressing "Couldn't guess match, please specify pattern" warnings in the Swift resource usage parser using a special comment directive (`// sur: skip`). It also adds comprehensive tests for this new behavior and makes a minor code style improvement.

**Warning suppression feature:**

* Added logic in `FuncCallVisitor.swift` to detect `// sur: skip` comments (including variations in whitespace and block/line comments) attached to resource usage sites, preventing the emission of unguessable-pattern warnings when present. [[1]](diffhunk://#diff-46c004e5bf0b1ab810036e0daad4531501f8ce332a8670abd65f07af09c58359R162-R199) [[2]](diffhunk://#diff-46c004e5bf0b1ab810036e0daad4531501f8ce332a8670abd65f07af09c58359R55-R57) [[3]](diffhunk://#diff-46c004e5bf0b1ab810036e0daad4531501f8ce332a8670abd65f07af09c58359R89-R91)

**Testing improvements:**

* Introduced a new test suite `WarningSkipTests.swift` to verify that warnings are correctly suppressed or emitted based on the presence of the `// sur: skip` directive in various positions and comment styles.

**Code quality:**

* Made a minor style improvement in `GeneratedResourceUsageTests.swift` by using more idiomatic Swift pattern matching.