### PR TITLE
Enhance initializer resolution and support static factories

### DIFF
--- a/Sources/SURCore/Explorer.swift
+++ b/Sources/SURCore/Explorer.swift
@@ -350,7 +350,9 @@ public final class Explorer {
 
         var usages: [ExploreUsage] = []
 
-        for result in results {
+        // Sort by path so the registry merge (later-wins on conflicting same-named types) is
+        // deterministic, rather than depending on nondeterministic task-group completion order.
+        for result in results.sorted(by: { $0.path < $1.path }) {
             usages.append(contentsOf: result.usages)
             pendingInits.append(contentsOf: result.pendingInits)
             mergeInitializerRegistry(result.typeRegistry, into: &typeRegistry)

--- a/Sources/SURCore/Explorer.swift
+++ b/Sources/SURCore/Explorer.swift
@@ -22,7 +22,7 @@ public final class Explorer {
     /// Per-target aggregation of user-type initializer signatures and the call sites that may
     /// pass resources into them. Resolved cross-file once every source has been parsed, just
     /// before `analyze()`. Reset at the start of each target.
-    private var typeRegistry: [String: [String: InitParameterType]] = [:]
+    private var typeRegistry: InitializerRegistry = [:]
     private var pendingInits: [PendingInitCall] = []
 
     public init(
@@ -353,10 +353,7 @@ public final class Explorer {
         for result in results {
             usages.append(contentsOf: result.usages)
             pendingInits.append(contentsOf: result.pendingInits)
-
-            for (type, parameters) in result.typeRegistry {
-                typeRegistry[type, default: [:]].merge(parameters) { _, new in new }
-            }
+            mergeInitializerRegistry(result.typeRegistry, into: &typeRegistry)
         }
 
         await storage.addUsages(usages)

--- a/Sources/SURCore/Explorer.swift
+++ b/Sources/SURCore/Explorer.swift
@@ -18,7 +18,13 @@ public final class Explorer {
     private let propertyKinds: [String: ExploreKind]
 
     let storage = Storage()
-    
+
+    /// Per-target aggregation of user-type initializer signatures and the call sites that may
+    /// pass resources into them. Resolved cross-file once every source has been parsed, just
+    /// before `analyze()`. Reset at the start of each target.
+    private var typeRegistry: [String: [String: InitParameterType]] = [:]
+    private var pendingInits: [PendingInitCall] = []
+
     public init(
         projectPath: Path,
         sourceRoot: Path,
@@ -151,7 +157,9 @@ public final class Explorer {
     
     private func explore(target: PBXNativeTarget) async throws {
         await storage.clean()
-        
+        typeRegistry.removeAll()
+        pendingInits.removeAll()
+
         guard let resources = try target.resourcesBuildPhase() else {
             // no sources, skip
             print("    No resources, skip")
@@ -166,7 +174,9 @@ public final class Explorer {
         if let synchronizedGroups = target.fileSystemSynchronizedGroups {
             try await explore(groups: synchronizedGroups)
         }
-        
+
+        await resolvePendingInits()
+
         try await analyze()
     }
     
@@ -318,26 +328,51 @@ public final class Explorer {
             propertyKinds: propertyKinds
         )
         
-        let usages = try await withThrowingTaskGroup(of: [ExploreUsage].self) { group in
+        let results = try await withThrowingTaskGroup(of: SwiftParseResult.self) { group in
             files.forEach { path in
                 if path.extension != "swift" {
                     return
                 }
-                
+
                 if excludedSources.contains(path) {
                     return
                 }
-                
+
                 let url = path.url
-                
+
                 group.addTask { @Sendable in
-                    try parser.parse(url)
+                    try parser.parseDetailed(url)
                 }
             }
-            
-            return try await group.reduce(into: [], +=)
+
+            return try await group.reduce(into: [SwiftParseResult]()) { $0.append($1) }
         }
-        
+
+        var usages: [ExploreUsage] = []
+
+        for result in results {
+            usages.append(contentsOf: result.usages)
+            pendingInits.append(contentsOf: result.pendingInits)
+
+            for (type, parameters) in result.typeRegistry {
+                typeRegistry[type, default: [:]].merge(parameters) { _, new in new }
+            }
+        }
+
+        await storage.addUsages(usages)
+    }
+
+    /// Resolves every collected initializer call site against the aggregated type registry,
+    /// recording a `.generated` usage for each resource argument — including resources nested in
+    /// type-inferred `.init(...)` calls. Runs after all sources are parsed, before `analyze()`.
+    private func resolvePendingInits() async {
+        let resolver = InitArgumentResolver(typeRegistry: typeRegistry, kinds: kinds)
+        let usages = resolver.resolve(pendingInits)
+
+        guard !usages.isEmpty else {
+            return
+        }
+
         await storage.addUsages(usages)
     }
 }

--- a/Sources/SURCore/Items/Explore/InitParameterType.swift
+++ b/Sources/SURCore/Items/Explore/InitParameterType.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// The kind of value an initializer parameter (or memberwise stored property) accepts,
+/// as far as asset detection cares: either a resource directly, or another user type
+/// whose own initializer may carry resources (enabling nested `.init` resolution).
+enum InitParameterType: Sendable, Equatable {
+    /// A resource-typed parameter, e.g. `ImageResource` → `.resource(.image)`.
+    case resource(ExploreKind)
+
+    /// A parameter typed as some user type by simple name, e.g. `Test` → `.named("Test")`.
+    /// Used to resolve a nested `.init(...)` whose type is inferred from this parameter.
+    case named(String)
+}
+
+/// A collected initializer call site, recorded during parsing and resolved against the
+/// cross-file type registry afterwards. `typeName` is the explicit callee type
+/// (`Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)`), or `nil` for an inferred `.init(...)`
+/// whose type comes from the enclosing parameter at resolution time.
+struct PendingInitCall: Sendable, Equatable {
+    var typeName: String?
+    var arguments: [PendingInitArgument]
+}
+
+/// One argument of a `PendingInitCall`: the bare members it passes directly (`.cat` → "cat")
+/// and any nested `.init(...)` calls whose type is inferred from this argument's parameter.
+struct PendingInitArgument: Sendable, Equatable {
+    /// The argument label, or `""` for a positional (`_`) parameter.
+    var label: String
+    var members: [String]
+    var nestedInits: [PendingInitCall]
+}
+
+/// Everything one parsed Swift file contributes: the asset usages it directly proves, the
+/// initializer signatures it declares, and the pending init call sites awaiting resolution.
+struct SwiftParseResult: Sendable {
+    var usages: [ExploreUsage]
+    var typeRegistry: [String: [String: InitParameterType]]
+    var pendingInits: [PendingInitCall]
+}

--- a/Sources/SURCore/Items/Explore/InitParameterType.swift
+++ b/Sources/SURCore/Items/Explore/InitParameterType.swift
@@ -12,12 +12,30 @@ enum InitParameterType: Sendable, Equatable {
     case named(String)
 }
 
-/// A collected initializer call site, recorded during parsing and resolved against the
-/// cross-file type registry afterwards. `typeName` is the explicit callee type
-/// (`Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)`), or `nil` for an inferred `.init(...)`
-/// whose type comes from the enclosing parameter at resolution time.
+/// The set of constructors a type exposes to asset detection, keyed by type name. Each type maps
+/// a *selector* — `"init"` for an initializer/memberwise init, or a static factory method's name —
+/// to that constructor's `label → parameter type` map. Built per file and merged across files.
+typealias InitializerRegistry = [String: [String: [String: InitParameterType]]]
+
+/// Deep-merges one initializer registry into another (`type → selector → label`), the later
+/// value winning on a conflict — used to combine per-file registries and a type's own
+/// declaration with its extensions.
+func mergeInitializerRegistry(_ source: InitializerRegistry, into target: inout InitializerRegistry) {
+    for (type, selectors) in source {
+        for (selector, parameters) in selectors {
+            target[type, default: [:]][selector, default: [:]].merge(parameters) { _, new in new }
+        }
+    }
+}
+
+/// A collected constructor call site, recorded during parsing and resolved against the cross-file
+/// type registry afterwards. `typeName` is the explicit callee type (`Foo(...)`, `Foo.init(...)`,
+/// `Outer.Inner(...)`, `Test.image(...)`), or `nil` for an inferred leading-dot call (`.init(...)`,
+/// `.image(...)`) whose type comes from the enclosing parameter at resolution time. `selector`
+/// is `"init"` for an initializer or the static factory method's name.
 struct PendingInitCall: Sendable, Equatable {
     var typeName: String?
+    var selector: String
     var arguments: [PendingInitArgument]
 }
 
@@ -34,6 +52,6 @@ struct PendingInitArgument: Sendable, Equatable {
 /// initializer signatures it declares, and the pending init call sites awaiting resolution.
 struct SwiftParseResult: Sendable {
     var usages: [ExploreUsage]
-    var typeRegistry: [String: [String: InitParameterType]]
+    var typeRegistry: InitializerRegistry
     var pendingInits: [PendingInitCall]
 }

--- a/Sources/SURCore/Items/Explore/InitParameterType.swift
+++ b/Sources/SURCore/Items/Explore/InitParameterType.swift
@@ -12,10 +12,16 @@ enum InitParameterType: Sendable, Equatable {
     case named(String)
 }
 
-/// The set of constructors a type exposes to asset detection, keyed by type name. Each type maps
-/// a *selector* — `"init"` for an initializer/memberwise init, or a static factory method's name —
-/// to that constructor's `label → parameter type` map. Built per file and merged across files.
-typealias InitializerRegistry = [String: [String: [String: InitParameterType]]]
+/// One constructor's parameters, keyed by argument label (or `#0`, `#1`, … for positional params).
+typealias InitParameterMap = [String: InitParameterType]
+
+/// The constructors a type exposes, keyed by *selector* — `"init"` for an initializer/memberwise
+/// init, or a static factory method's name.
+typealias TypeConstructors = [String: InitParameterMap]
+
+/// The set of constructors every known type exposes to asset detection, keyed by type name.
+/// Built per file and merged across files.
+typealias InitializerRegistry = [String: TypeConstructors]
 
 /// Deep-merges one initializer registry into another (`type → selector → label`), the later
 /// value winning on a conflict — used to combine per-file registries and a type's own
@@ -51,6 +57,8 @@ struct PendingInitArgument: Sendable, Equatable {
 /// Everything one parsed Swift file contributes: the asset usages it directly proves, the
 /// initializer signatures it declares, and the pending init call sites awaiting resolution.
 struct SwiftParseResult: Sendable {
+    /// Source file path, used to merge per-file registries in a deterministic order.
+    var path: String
     var usages: [ExploreUsage]
     var typeRegistry: InitializerRegistry
     var pendingInits: [PendingInitCall]

--- a/Sources/SURCore/Parsers/InitArgumentResolver.swift
+++ b/Sources/SURCore/Parsers/InitArgumentResolver.swift
@@ -1,0 +1,44 @@
+/// Resolves collected initializer call sites against the aggregated user-type registry,
+/// turning a resource passed to a struct/class/actor initializer — directly or through a
+/// type-inferred nested `.init(...)` — into a `.generated` usage. Pure and cross-file: it
+/// only needs the merged registry, so it is shared by `Explorer` and exercised directly in tests.
+struct InitArgumentResolver {
+    let typeRegistry: [String: [String: InitParameterType]]
+    let kinds: Set<ExploreKind>
+
+    func resolve(_ pendingInits: [PendingInitCall]) -> [ExploreUsage] {
+        var usages: [ExploreUsage] = []
+
+        for pending in pendingInits {
+            resolve(pending, expectedType: nil, into: &usages)
+        }
+
+        return usages
+    }
+
+    private func resolve(_ call: PendingInitCall, expectedType: String?, into usages: inout [ExploreUsage]) {
+        guard let typeName = call.typeName ?? expectedType, let parameters = typeRegistry[typeName] else {
+            return
+        }
+
+        for argument in call.arguments {
+            guard let parameterType = parameters[argument.label] else {
+                continue
+            }
+
+            switch parameterType {
+            case .resource(let kind):
+                guard kinds.contains(kind) else {
+                    continue
+                }
+
+                usages.append(contentsOf: argument.members.map { .generated($0, kind) })
+
+            case .named(let innerType):
+                for nested in argument.nestedInits {
+                    resolve(nested, expectedType: innerType, into: &usages)
+                }
+            }
+        }
+    }
+}

--- a/Sources/SURCore/Parsers/InitArgumentResolver.swift
+++ b/Sources/SURCore/Parsers/InitArgumentResolver.swift
@@ -3,7 +3,7 @@
 /// type-inferred nested `.init(...)` — into a `.generated` usage. Pure and cross-file: it
 /// only needs the merged registry, so it is shared by `Explorer` and exercised directly in tests.
 struct InitArgumentResolver {
-    let typeRegistry: [String: [String: InitParameterType]]
+    let typeRegistry: InitializerRegistry
     let kinds: Set<ExploreKind>
 
     func resolve(_ pendingInits: [PendingInitCall]) -> [ExploreUsage] {
@@ -17,7 +17,10 @@ struct InitArgumentResolver {
     }
 
     private func resolve(_ call: PendingInitCall, expectedType: String?, into usages: inout [ExploreUsage]) {
-        guard let typeName = call.typeName ?? expectedType, let parameters = typeRegistry[typeName] else {
+        guard
+            let typeName = call.typeName ?? expectedType,
+            let parameters = typeRegistry[typeName]?[call.selector]
+        else {
             return
         }
 

--- a/Sources/SURCore/Parsers/SwiftParser.swift
+++ b/Sources/SURCore/Parsers/SwiftParser.swift
@@ -57,6 +57,7 @@ struct SwiftParser: Sendable {
         )
 
         return SwiftParseResult(
+            path: path.path,
             usages: visitor.usages,
             typeRegistry: visitor.typeRegistry,
             pendingInits: visitor.pendingInits

--- a/Sources/SURCore/Parsers/SwiftParser.swift
+++ b/Sources/SURCore/Parsers/SwiftParser.swift
@@ -23,14 +23,29 @@ struct SwiftParser: Sendable {
     func parse(
         _ path: URL
     ) throws -> [ExploreUsage] {
-        let file = try String(contentsOf: path)
-        return parse(source: file, at: path)
+        try parseDetailed(path).usages
     }
 
     func parse(
         source: String,
         at path: URL = URL(fileURLWithPath: "<source>")
     ) -> [ExploreUsage] {
+        parseDetailed(source: source, at: path).usages
+    }
+
+    /// Parses a file, returning not just the proven usages but also the initializer signatures
+    /// it declares and the initializer call sites awaiting cross-file resolution.
+    func parseDetailed(
+        _ path: URL
+    ) throws -> SwiftParseResult {
+        let file = try String(contentsOf: path)
+        return parseDetailed(source: file, at: path)
+    }
+
+    func parseDetailed(
+        source: String,
+        at path: URL = URL(fileURLWithPath: "<source>")
+    ) -> SwiftParseResult {
         let tree = Parser.parse(source: source)
         let visitor = SourceVisitor(
             showWarnings: showWarnings,
@@ -41,6 +56,10 @@ struct SwiftParser: Sendable {
             tree
         )
 
-        return visitor.usages
+        return SwiftParseResult(
+            usages: visitor.usages,
+            typeRegistry: visitor.typeRegistry,
+            pendingInits: visitor.pendingInits
+        )
     }
 }

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+GeneratedAssets.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+GeneratedAssets.swift
@@ -1,0 +1,105 @@
+import SwiftSyntax
+
+/// Resolution of R.swift-style access (`R.image.star`) and Xcode-generated asset symbols
+/// (`UIImage.star`, `Image(.star)`, `UIImage(resource: .star)`) reached through a
+/// `DeclReferenceExprSyntax`. Kept separate from the visit overrides.
+extension SourceVisitor {
+    func findR(
+        in node: DeclReferenceExprSyntax,
+        with kind: ExploreKind
+    ) -> ExploreUsage? {
+        guard node.baseName.text == "R" else {
+            return nil
+        }
+
+        let members = members(in: node).dropFirst()
+
+        guard members.first == kind.rawValue, let name = members.dropFirst().first else {
+            return nil
+        }
+
+        return .rswift(name, kind)
+    }
+
+    func findGeneratedAsset(
+        in node: DeclReferenceExprSyntax,
+        with kind: ExploreKind
+    ) -> ExploreUsage? {
+        guard Self.generatedClassKinds[node.baseName.text] == kind else {
+            return nil
+        }
+
+        if let call = initializerCall(of: node) {
+            // collectValue resolves ternary / if / switch branches before recording, so
+            // `UIImage(resource: flag ? .a : .b)` records both assets. Usages are appended
+            // directly; a DeclRef has no children worth skipping, so returning nil is fine.
+            if call.arguments.count == 1, let argument = call.arguments.first {
+                collectValue(argument.expression, with: kind)
+            }
+
+            return nil
+        }
+        else {
+            var members = members(in: node).array()
+
+            if let first = members.first, Self.assetModules.contains(first) {
+                members.removeFirst()
+            }
+
+            // `members.first == baseName` rejects chains rooted in an unknown namespace:
+            // in `MyKit.Image.star` the first member is `MyKit`, so `Image` there is some
+            // custom type, not the SwiftUI one.
+            guard members.count >= 2, members.first == node.baseName.text else {
+                return nil
+            }
+
+            let name = members[1]
+
+            // Asset symbols can never be named `init`; `UIImage.init(named:)` is not an asset.
+            guard name != "init" else {
+                return nil
+            }
+
+            return .generated(name, kind)
+        }
+    }
+
+    /// The call node when `node` is the called type of an initializer call — either plain
+    /// `UIImage(...)` or module-qualified `SwiftUI.Image(...)`.
+    private func initializerCall(of node: DeclReferenceExprSyntax) -> FunctionCallExprSyntax? {
+        if let call = node.parent?.as(FunctionCallExprSyntax.self) {
+            return call
+        }
+
+        guard
+            let member = node.parent?.as(MemberAccessExprSyntax.self),
+            member.declName.id == node.id,
+            let base = member.base?.as(DeclReferenceExprSyntax.self),
+            Self.assetModules.contains(base.baseName.text)
+        else {
+            return nil
+        }
+
+        return member.parent?.as(FunctionCallExprSyntax.self)
+    }
+
+    private func members(in node: DeclReferenceExprSyntax) -> some RandomAccessCollection<String> {
+        guard let parent = node.parent?.as(MemberAccessExprSyntax.self) else {
+            return []
+        }
+
+        let usage = sequence(first: parent) { $0.parent?.as(MemberAccessExprSyntax.self) }
+            .array()
+            .last
+
+        guard let usage else {
+            return []
+        }
+
+        let visitor = MemberVisitor(viewMode: viewMode)
+
+        visitor.walk(usage)
+
+        return visitor.members
+    }
+}

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+InitArguments.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+InitArguments.swift
@@ -1,0 +1,300 @@
+import SwiftSyntax
+
+/// Collection of user-type initializer signatures and initializer call sites, used to
+/// resolve a resource passed as an argument to a user-defined type's initializer —
+/// `CardStyle(icon: .star)` or, with the type inferred from the parameter,
+/// `Foo(test: .init(image: .cat))`. The registry and pending calls are aggregated and
+/// resolved cross-file by `Explorer`, since the declaration and the call site can live
+/// in different files.
+extension SourceVisitor {
+    /// Records the resource/named-type parameters of a type declaration into `typeRegistry`.
+    /// When the type declares initializers, their parameters define the labels; otherwise a
+    /// struct's stored properties define its memberwise-init labels. `memberwiseFallback` is
+    /// `true` only for structs — classes and actors have no synthesized memberwise init.
+    func registerType(
+        named name: String,
+        members: MemberBlockItemListSyntax,
+        memberwiseFallback: Bool
+    ) {
+        var parameters: [String: InitParameterType] = [:]
+
+        let initializers = members.compactMap { $0.decl.as(InitializerDeclSyntax.self) }
+
+        if !initializers.isEmpty {
+            for initializer in initializers {
+                for parameter in initializer.signature.parameterClause.parameters {
+                    guard let type = parameterType(for: parameter.type) else {
+                        continue
+                    }
+
+                    let label = parameter.firstName.tokenKind == .wildcard ? "" : parameter.firstName.text
+                    parameters[label] = type
+                }
+            }
+        }
+        else if memberwiseFallback {
+            for member in members {
+                guard let variable = member.decl.as(VariableDeclSyntax.self) else {
+                    continue
+                }
+
+                let isLet = variable.bindingSpecifier.tokenKind == .keyword(.let)
+
+                for binding in variable.bindings {
+                    // Computed properties and `let`s with a default value never appear in the
+                    // synthesized memberwise initializer, so they contribute no call label.
+                    guard
+                        let type = binding.typeAnnotation?.type,
+                        !isComputedProperty(binding.accessorBlock),
+                        !(isLet && binding.initializer != nil),
+                        let label = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+                        let parameterType = parameterType(for: type)
+                    else {
+                        continue
+                    }
+
+                    parameters[label] = parameterType
+                }
+            }
+        }
+
+        guard !parameters.isEmpty else {
+            return
+        }
+
+        typeRegistry[name, default: [:]].merge(parameters) { _, new in new }
+    }
+
+    /// Records an explicit-type initializer call (`Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)`)
+    /// as a pending call to resolve later. Inferred `.init(...)` calls are not recorded here —
+    /// they carry no type on their own and are captured as nested children of their enclosing call.
+    func collectPendingInit(of node: FunctionCallExprSyntax) {
+        guard case .explicit(let typeName)? = initCalleeKind(of: node.calledExpression) else {
+            return
+        }
+
+        let pending = buildPendingInit(node, fallbackType: typeName)
+
+        if !pending.arguments.isEmpty {
+            pendingInits.append(pending)
+        }
+    }
+
+    /// Records `.init(...)` / explicit calls found in a value assigned to a named-user-typed
+    /// context (`let x: Foo = .init(...)`, a `Foo`-returning body, a `Foo` parameter default),
+    /// pinning the inferred `.init` to the annotated type. Explicit calls are left to
+    /// `collectPendingInit`, which captures them via the visitor's own traversal.
+    func collectNamedTypeValue(_ expression: ExprSyntax, expectedType: String) {
+        for leaf in resolveTail(expression) {
+            if let array = leaf.as(ArrayExprSyntax.self) {
+                array.elements.forEach { collectNamedTypeValue($0.expression, expectedType: expectedType) }
+            }
+            else if
+                let call = leaf.as(FunctionCallExprSyntax.self),
+                case .inferred? = initCalleeKind(of: call.calledExpression) {
+                let pending = buildPendingInit(call, fallbackType: expectedType)
+                if !pending.arguments.isEmpty {
+                    pendingInits.append(pending)
+                }
+            }
+        }
+    }
+
+    /// Collects named-type `.init` values returned (explicitly or implicitly) by a body,
+    /// mirroring `collectReturnedAssets` but for nested-init resolution.
+    func collectNamedTypeReturns(in statements: CodeBlockItemListSyntax, expectedType: String) {
+        let visitor = ReturnVisitor(viewMode: viewMode)
+        statements.forEach { visitor.walk($0) }
+
+        let leaves = visitor.expressions.flatMap { resolveTail($0) } + implicitTail(of: statements)
+
+        leaves.forEach { collectNamedTypeValue($0, expectedType: expectedType) }
+    }
+
+    // MARK: - Building
+
+    /// Builds a `PendingInitCall` from an initializer call, recursively capturing nested inferred
+    /// `.init(...)` arguments. `fallbackType` supplies the type for an inferred callee (from the
+    /// enclosing parameter or annotation); an explicit callee uses its own type name.
+    private func buildPendingInit(_ call: FunctionCallExprSyntax, fallbackType: String?) -> PendingInitCall {
+        let typeName: String?
+        switch initCalleeKind(of: call.calledExpression) {
+        case .explicit(let name): typeName = name
+        case .inferred, nil: typeName = fallbackType
+        }
+
+        var arguments: [PendingInitArgument] = []
+
+        for argument in call.arguments {
+            var members: [String] = []
+            var nestedInits: [PendingInitCall] = []
+            resolveArgumentValue(argument.expression, members: &members, nestedInits: &nestedInits)
+
+            guard !members.isEmpty || !nestedInits.isEmpty else {
+                continue
+            }
+
+            arguments.append(
+                PendingInitArgument(
+                    label: argument.label?.text ?? "",
+                    members: members,
+                    nestedInits: nestedInits
+                )
+            )
+        }
+
+        return PendingInitCall(typeName: typeName, arguments: arguments)
+    }
+
+    /// Resolves an argument expression into the bare members it passes directly and the inferred
+    /// `.init(...)` calls it nests. Explicit `Type(...)` calls are intentionally skipped — the
+    /// visitor records those independently, so nesting them here would double-count.
+    private func resolveArgumentValue(
+        _ expression: ExprSyntax,
+        members: inout [String],
+        nestedInits: inout [PendingInitCall]
+    ) {
+        for leaf in resolveTail(expression) {
+            if let array = leaf.as(ArrayExprSyntax.self) {
+                for element in array.elements {
+                    resolveArgumentValue(element.expression, members: &members, nestedInits: &nestedInits)
+                }
+            }
+            else if let sequence = leaf.as(SequenceExprSyntax.self) {
+                // Unfolded ternary argument: `flag ? .a : .b` arrives as a flat sequence whose
+                // `then` branch hides inside an UnresolvedTernaryExprSyntax element.
+                for element in sequence.elements {
+                    let unwrapped = element.as(UnresolvedTernaryExprSyntax.self)?.thenExpression ?? element
+                    resolveArgumentValue(unwrapped, members: &members, nestedInits: &nestedInits)
+                }
+            }
+            else if let call = leaf.as(FunctionCallExprSyntax.self),
+                    case .inferred? = initCalleeKind(of: call.calledExpression) {
+                nestedInits.append(buildPendingInit(call, fallbackType: nil))
+            }
+            else if let name = innermostBareMember(of: leaf) {
+                members.append(name)
+            }
+        }
+    }
+
+    // MARK: - Type helpers
+
+    /// The `InitParameterType` for a parameter/property type: a resource kind if it resolves to
+    /// one, else the simple user-type name for nested-init resolution.
+    private func parameterType(for type: TypeSyntax?) -> InitParameterType? {
+        if let kind = typedKind(for: type) {
+            return .resource(kind)
+        }
+
+        if let name = namedType(for: type) {
+            return .named(name)
+        }
+
+        return nil
+    }
+
+    /// The simple name of a (non-resource) named type, unwrapping `Optional` / `Array` / IUO
+    /// sugar and generic forms, and taking the final component of a module-qualified type.
+    func namedType(for type: TypeSyntax?) -> String? {
+        guard let type else {
+            return nil
+        }
+
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return namedType(for: optional.wrappedType)
+        }
+
+        if let optional = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return namedType(for: optional.wrappedType)
+        }
+
+        if let array = type.as(ArrayTypeSyntax.self) {
+            return namedType(for: array.element)
+        }
+
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            let name = identifier.name.text
+
+            if name == "Array" || name == "Optional" {
+                if let argument = identifier.genericArgumentClause?.arguments.first?.argument.as(TypeSyntax.self) {
+                    return namedType(for: argument)
+                }
+                return nil
+            }
+
+            return name
+        }
+
+        if let member = type.as(MemberTypeSyntax.self) {
+            return member.name.text
+        }
+
+        return nil
+    }
+
+    /// Whether a property's accessor block makes it computed (a shorthand or explicit `get`),
+    /// as opposed to a stored property with only `willSet` / `didSet` observers.
+    private func isComputedProperty(_ accessorBlock: AccessorBlockSyntax?) -> Bool {
+        guard let accessorBlock else {
+            return false
+        }
+
+        switch accessorBlock.accessors {
+        case .getter:
+            return true
+
+        case .accessors(let accessors):
+            return accessors.contains { $0.accessorSpecifier.tokenKind == .keyword(.get) }
+        }
+    }
+
+    // MARK: - Callee classification
+
+    private enum InitCalleeKind {
+        /// `Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)` — the type name is known.
+        case explicit(String)
+        /// `.init(...)` — the type is inferred from the enclosing context.
+        case inferred
+    }
+
+    /// Classifies an initializer-call callee, or returns `nil` when the call is not an
+    /// initializer-style call we resolve (lowercase function/method calls, member chains).
+    private func initCalleeKind(of callee: ExprSyntax) -> InitCalleeKind? {
+        if let reference = callee.as(DeclReferenceExprSyntax.self) {
+            let name = reference.baseName.text
+            return name.first?.isUppercase == true ? .explicit(name) : nil
+        }
+
+        guard let member = callee.as(MemberAccessExprSyntax.self) else {
+            return nil
+        }
+
+        let name = member.declName.baseName.text
+
+        if name == "init" {
+            // `Type.init(...)` carries its type in the base; bare `.init(...)` is inferred.
+            if let base = member.base, let typeName = baseTypeName(of: base) {
+                return .explicit(typeName)
+            }
+            return .inferred
+        }
+
+        // `Outer.Inner(...)` — an uppercase final component is a nested type initializer;
+        // a lowercase one (`view.tint(...)`) is a method call handled elsewhere.
+        return name.first?.isUppercase == true ? .explicit(name) : nil
+    }
+
+    /// The final type-name component of a `.init` base (`X` in `X.init`, `Inner` in `A.Inner.init`).
+    private func baseTypeName(of expression: ExprSyntax) -> String? {
+        if let reference = expression.as(DeclReferenceExprSyntax.self) {
+            return reference.baseName.text
+        }
+
+        if let member = expression.as(MemberAccessExprSyntax.self) {
+            return member.declName.baseName.text
+        }
+
+        return nil
+    }
+}

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+InitArguments.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+InitArguments.swift
@@ -1,11 +1,35 @@
 import SwiftSyntax
 
+/// How an initializer-style callee resolves: an explicit type (`Foo(...)`, `Foo.init(...)`,
+/// `Outer.Inner(...)`, `Test.image(...)`) or an inferred leading-dot call (`.init(...)`,
+/// `.image(...)`) whose type comes from context. `selector` is `"init"` or a factory method name.
+private enum InitCalleeKind {
+    case explicit(typeName: String, selector: String)
+    case inferred(selector: String)
+}
+
+/// The synthetic registry/call label for the positional (`_`) parameter/argument at `index`.
+/// Keyed by position so distinct positional parameters never collide under a shared empty label.
+private func positionalLabel(_ index: Int) -> String {
+    "#\(index)"
+}
+
 /// Collection of user-type constructor signatures and constructor call sites, used to resolve a
 /// resource passed to a user-defined type's initializer or static factory — `CardStyle(icon: .star)`,
 /// a type-inferred `Foo(test: .init(image: .cat))`, or a static factory `Foo(test: .image(.frog))`.
 /// The registry and pending calls are aggregated and resolved cross-file by `Explorer`, since a
 /// declaration and its call site (and its extensions) can live in different files.
 extension SourceVisitor {
+    /// Type names that can never carry a resource, so they are not recorded as `.named` parameters
+    /// (which would only bloat the registry). Kept deliberately conservative — only stdlib scalars.
+    private static let nonResourceTypeNames: Set<String> = [
+        "String", "Substring", "Character", "Bool",
+        "Int", "Int8", "Int16", "Int32", "Int64",
+        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+        "Double", "Float", "Float16", "CGFloat",
+        "Date", "URL", "Data", "UUID", "TimeInterval", "Decimal",
+    ]
+
     /// Records a type's constructors into `typeRegistry`: its initializers (selector `"init"`),
     /// a struct's synthesized memberwise init when it declares none, and any static factory methods
     /// returning `Self` or the type itself (selector = method name). Called for the type's own
@@ -16,7 +40,7 @@ extension SourceVisitor {
         members: MemberBlockItemListSyntax,
         memberwiseFallback: Bool
     ) {
-        var selectors: [String: [String: InitParameterType]] = [:]
+        var selectors: TypeConstructors = [:]
 
         let initializers = members.compactMap { $0.decl.as(InitializerDeclSyntax.self) }
 
@@ -52,7 +76,7 @@ extension SourceVisitor {
             return
         }
 
-        let pending = buildPendingInit(node, fallbackType: typeName, selector: selector)
+        let pending = buildPendingInit(node, typeName: typeName, selector: selector)
 
         if !pending.arguments.isEmpty {
             pendingInits.append(pending)
@@ -64,17 +88,18 @@ extension SourceVisitor {
     /// parameter default), pinning them to the resolved type. Explicit calls are left to
     /// `collectPendingInit`, which captures them via the visitor's own traversal.
     func collectNamedTypeValue(_ expression: ExprSyntax, expectedType: String) {
-        for leaf in resolveTail(expression) {
-            if let array = leaf.as(ArrayExprSyntax.self) {
-                array.elements.forEach { collectNamedTypeValue($0.expression, expectedType: expectedType) }
-            }
-            else if
+        for leaf in shallowLeaves(of: expression) {
+            guard
                 let call = leaf.as(FunctionCallExprSyntax.self),
-                case .inferred(let selector)? = initCalleeKind(of: call.calledExpression) {
-                let pending = buildPendingInit(call, fallbackType: expectedType, selector: selector)
-                if !pending.arguments.isEmpty {
-                    pendingInits.append(pending)
-                }
+                case .inferred(let selector)? = initCalleeKind(of: call.calledExpression)
+            else {
+                continue
+            }
+
+            let pending = buildPendingInit(call, typeName: expectedType, selector: selector)
+
+            if !pending.arguments.isEmpty {
+                pendingInits.append(pending)
             }
         }
     }
@@ -96,7 +121,11 @@ extension SourceVisitor {
             return nil
         }
 
-        return name == "Self" ? enclosingTypeNames.last : name
+        if name == "Self" {
+            return enclosingTypeNames.last.flatMap { $0 }
+        }
+
+        return name
     }
 
     /// The concrete type a constrained protocol extension pins `Self` to via `where Self == X`
@@ -125,25 +154,38 @@ extension SourceVisitor {
         return defaultName
     }
 
+    /// The simple name of a (non-resource) named type, unwrapping `Optional` / `Array` / IUO /
+    /// `any` / `some` sugar and generic forms, and taking the final component of a qualified type.
+    func namedType(for type: TypeSyntax?) -> String? {
+        guard let leaf = unwrappedType(type) else {
+            return nil
+        }
+
+        if let identifier = leaf.as(IdentifierTypeSyntax.self) {
+            let name = identifier.name.text
+            return name == "Array" || name == "Optional" ? nil : name
+        }
+
+        if let member = leaf.as(MemberTypeSyntax.self) {
+            return member.name.text
+        }
+
+        return nil
+    }
+
     // MARK: - Building
 
     /// Builds a `PendingInitCall` from a constructor call, recursively capturing nested inferred
-    /// leading-dot arguments. `fallbackType` supplies the type for an inferred callee (from the
-    /// enclosing parameter or annotation); an explicit callee uses its own type name.
+    /// leading-dot arguments. `typeName` is the resolved type (explicit name, the inferred context
+    /// type, or `nil` for a nested inferred call resolved from its parameter at resolution time).
     private func buildPendingInit(
         _ call: FunctionCallExprSyntax,
-        fallbackType: String?,
+        typeName: String?,
         selector: String
     ) -> PendingInitCall {
-        let typeName: String?
-        switch initCalleeKind(of: call.calledExpression) {
-        case .explicit(let name, _): typeName = name
-        case .inferred, nil: typeName = fallbackType
-        }
-
         var arguments: [PendingInitArgument] = []
 
-        for argument in call.arguments {
+        for (index, argument) in call.arguments.enumerated() {
             var members: [String] = []
             var nestedInits: [PendingInitCall] = []
             resolveArgumentValue(argument.expression, members: &members, nestedInits: &nestedInits)
@@ -154,7 +196,7 @@ extension SourceVisitor {
 
             arguments.append(
                 PendingInitArgument(
-                    label: argument.label?.text ?? "",
+                    label: argument.label?.text ?? positionalLabel(index),
                     members: members,
                     nestedInits: nestedInits
                 )
@@ -172,23 +214,11 @@ extension SourceVisitor {
         members: inout [String],
         nestedInits: inout [PendingInitCall]
     ) {
-        for leaf in resolveTail(expression) {
-            if let array = leaf.as(ArrayExprSyntax.self) {
-                for element in array.elements {
-                    resolveArgumentValue(element.expression, members: &members, nestedInits: &nestedInits)
-                }
-            }
-            else if let sequence = leaf.as(SequenceExprSyntax.self) {
-                // Unfolded ternary argument: `flag ? .a : .b` arrives as a flat sequence whose
-                // `then` branch hides inside an UnresolvedTernaryExprSyntax element.
-                for element in sequence.elements {
-                    let unwrapped = element.as(UnresolvedTernaryExprSyntax.self)?.thenExpression ?? element
-                    resolveArgumentValue(unwrapped, members: &members, nestedInits: &nestedInits)
-                }
-            }
-            else if let call = leaf.as(FunctionCallExprSyntax.self),
-                    case .inferred(let selector)? = initCalleeKind(of: call.calledExpression) {
-                nestedInits.append(buildPendingInit(call, fallbackType: nil, selector: selector))
+        for leaf in shallowLeaves(of: expression) {
+            if
+                let call = leaf.as(FunctionCallExprSyntax.self),
+                case .inferred(let selector)? = initCalleeKind(of: call.calledExpression) {
+                nestedInits.append(buildPendingInit(call, typeName: nil, selector: selector))
             }
             else if let name = innermostBareMember(of: leaf) {
                 members.append(name)
@@ -199,15 +229,17 @@ extension SourceVisitor {
     // MARK: - Signature helpers
 
     /// The `label → parameter type` map of a parameter list, keeping only resource/named-typed ones.
-    private func parameterTypes(of parameters: FunctionParameterListSyntax) -> [String: InitParameterType] {
-        var result: [String: InitParameterType] = [:]
+    private func parameterTypes(of parameters: FunctionParameterListSyntax) -> InitParameterMap {
+        var result: InitParameterMap = [:]
 
-        for parameter in parameters {
+        for (index, parameter) in parameters.enumerated() {
             guard let type = parameterType(for: parameter.type) else {
                 continue
             }
 
-            let label = parameter.firstName.tokenKind == .wildcard ? "" : parameter.firstName.text
+            let label = parameter.firstName.tokenKind == .wildcard
+                ? positionalLabel(index)
+                : parameter.firstName.text
             result[label] = type
         }
 
@@ -216,8 +248,8 @@ extension SourceVisitor {
 
     /// The memberwise initializer's `label → parameter type` map, from a struct's stored properties.
     /// Computed properties and `let`s with a default value never appear in the synthesized init.
-    private func memberwiseParameters(of members: MemberBlockItemListSyntax) -> [String: InitParameterType] {
-        var result: [String: InitParameterType] = [:]
+    private func memberwiseParameters(of members: MemberBlockItemListSyntax) -> InitParameterMap {
+        var result: InitParameterMap = [:]
 
         for member in members {
             guard let variable = member.decl.as(VariableDeclSyntax.self) else {
@@ -250,8 +282,8 @@ extension SourceVisitor {
     private func staticFactories(
         of members: MemberBlockItemListSyntax,
         returning typeName: String
-    ) -> [(selector: String, parameters: [String: InitParameterType])] {
-        var factories: [(String, [String: InitParameterType])] = []
+    ) -> [(selector: String, parameters: InitParameterMap)] {
+        var factories: [(String, InitParameterMap)] = []
 
         for member in members {
             guard
@@ -280,94 +312,35 @@ extension SourceVisitor {
     // MARK: - Type helpers
 
     /// The `InitParameterType` for a parameter/property type: a resource kind if it resolves to
-    /// one, else the simple user-type name for nested constructor resolution.
+    /// one, else the simple user-type name for nested constructor resolution (excluding stdlib
+    /// scalars that can never carry a resource).
     private func parameterType(for type: TypeSyntax?) -> InitParameterType? {
         if let kind = typedKind(for: type) {
             return .resource(kind)
         }
 
-        if let name = namedType(for: type) {
+        if let name = namedType(for: type), !Self.nonResourceTypeNames.contains(name) {
             return .named(name)
         }
 
         return nil
     }
 
-    /// The simple name of a (non-resource) named type, unwrapping `Optional` / `Array` / IUO
-    /// sugar and generic forms, and taking the final component of a module-qualified type.
-    func namedType(for type: TypeSyntax?) -> String? {
-        guard let type else {
-            return nil
-        }
-
-        if let optional = type.as(OptionalTypeSyntax.self) {
-            return namedType(for: optional.wrappedType)
-        }
-
-        if let optional = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
-            return namedType(for: optional.wrappedType)
-        }
-
-        if let array = type.as(ArrayTypeSyntax.self) {
-            return namedType(for: array.element)
-        }
-
-        // `any TestProtocol` / `some TestProtocol` → the constraint's name.
-        if let someOrAny = type.as(SomeOrAnyTypeSyntax.self) {
-            return namedType(for: someOrAny.constraint)
-        }
-
-        if let identifier = type.as(IdentifierTypeSyntax.self) {
-            let name = identifier.name.text
-
-            if name == "Array" || name == "Optional" {
-                if let argument = identifier.genericArgumentClause?.arguments.first?.argument.as(TypeSyntax.self) {
-                    return namedType(for: argument)
-                }
-                return nil
-            }
-
-            return name
-        }
-
-        if let member = type.as(MemberTypeSyntax.self) {
-            return member.name.text
-        }
-
-        return nil
-    }
-
-    /// Whether a property's accessor block makes it computed (a shorthand or explicit `get`),
-    /// as opposed to a stored property with only `willSet` / `didSet` observers.
+    /// Whether a property's accessor block makes it computed (a getter), as opposed to a stored
+    /// property with only `willSet` / `didSet` observers. Shares the getter probing of
+    /// `getterStatements(of:)`.
     private func isComputedProperty(_ accessorBlock: AccessorBlockSyntax?) -> Bool {
-        guard let accessorBlock else {
-            return false
-        }
-
-        switch accessorBlock.accessors {
-        case .getter:
-            return true
-
-        case .accessors(let accessors):
-            return accessors.contains { $0.accessorSpecifier.tokenKind == .keyword(.get) }
-        }
+        getterStatements(of: accessorBlock) != nil
     }
 
     // MARK: - Callee classification
-
-    private enum InitCalleeKind {
-        /// `Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)`, `Test.image(...)` — type and selector known.
-        case explicit(typeName: String, selector: String)
-        /// `.init(...)`, `.image(...)` — the type is inferred from context; the selector is known.
-        case inferred(selector: String)
-    }
 
     /// Classifies a constructor-call callee, or returns `nil` when the call is not a constructor
     /// call we resolve (plain functions, instance methods, deeper member chains).
     private func initCalleeKind(of callee: ExprSyntax) -> InitCalleeKind? {
         if let reference = callee.as(DeclReferenceExprSyntax.self) {
             let name = reference.baseName.text
-            return name.first?.isUppercase == true ? .explicit(typeName: name, selector: "init") : nil
+            return isTypeName(name) ? .explicit(typeName: name, selector: "init") : nil
         }
 
         guard let member = callee.as(MemberAccessExprSyntax.self) else {
@@ -382,12 +355,12 @@ extension SourceVisitor {
                 return .inferred(selector: "init")
             }
             // `.image(...)` — a static factory; uppercase leading-dot calls are out of scope.
-            return name.first?.isLowercase == true ? .inferred(selector: name) : nil
+            return isTypeName(name) ? nil : .inferred(selector: name)
         }
 
-        // Qualified call: the base must name a type (uppercase final component); a lowercase base
-        // (`view.tint(...)`) is an instance method handled elsewhere.
-        guard let baseName = baseTypeName(of: base), baseName.first?.isUppercase == true else {
+        // Qualified call: the base must name a type; a value base (`view.tint(...)`) is an instance
+        // method handled elsewhere.
+        guard let baseName = baseTypeName(of: base), isTypeName(baseName) else {
             return nil
         }
 
@@ -395,13 +368,19 @@ extension SourceVisitor {
             return .explicit(typeName: baseName, selector: "init")
         }
 
-        // `Outer.Inner(...)` — an uppercase final component is a nested type's initializer;
-        // `Test.image(...)` — a lowercase one is a static factory on the base type.
-        if name.first?.isUppercase == true {
+        // `Outer.Inner(...)` — a type-named final component is a nested type's initializer;
+        // `Test.image(...)` — a method-named one is a static factory on the base type.
+        if isTypeName(name) {
             return .explicit(typeName: name, selector: "init")
         }
 
         return .explicit(typeName: baseName, selector: name)
+    }
+
+    /// Whether an identifier names a type, tolerating leading underscores (`_InternalStyle`) so
+    /// generated/internal types are not mistaken for instances.
+    private func isTypeName(_ name: String) -> Bool {
+        name.drop { $0 == "_" }.first?.isUppercase == true
     }
 
     /// The final type-name component of a qualified base (`X` in `X.init`, `Type` in `Module.Type.f`).

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+InitArguments.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+InitArguments.swift
@@ -1,88 +1,67 @@
 import SwiftSyntax
 
-/// Collection of user-type initializer signatures and initializer call sites, used to
-/// resolve a resource passed as an argument to a user-defined type's initializer —
-/// `CardStyle(icon: .star)` or, with the type inferred from the parameter,
-/// `Foo(test: .init(image: .cat))`. The registry and pending calls are aggregated and
-/// resolved cross-file by `Explorer`, since the declaration and the call site can live
-/// in different files.
+/// Collection of user-type constructor signatures and constructor call sites, used to resolve a
+/// resource passed to a user-defined type's initializer or static factory — `CardStyle(icon: .star)`,
+/// a type-inferred `Foo(test: .init(image: .cat))`, or a static factory `Foo(test: .image(.frog))`.
+/// The registry and pending calls are aggregated and resolved cross-file by `Explorer`, since a
+/// declaration and its call site (and its extensions) can live in different files.
 extension SourceVisitor {
-    /// Records the resource/named-type parameters of a type declaration into `typeRegistry`.
-    /// When the type declares initializers, their parameters define the labels; otherwise a
-    /// struct's stored properties define its memberwise-init labels. `memberwiseFallback` is
-    /// `true` only for structs — classes and actors have no synthesized memberwise init.
+    /// Records a type's constructors into `typeRegistry`: its initializers (selector `"init"`),
+    /// a struct's synthesized memberwise init when it declares none, and any static factory methods
+    /// returning `Self` or the type itself (selector = method name). Called for the type's own
+    /// declaration and for each `extension`, so factories added in extensions are captured too.
+    /// `memberwiseFallback` is `true` only for a struct's primary declaration.
     func registerType(
         named name: String,
         members: MemberBlockItemListSyntax,
         memberwiseFallback: Bool
     ) {
-        var parameters: [String: InitParameterType] = [:]
+        var selectors: [String: [String: InitParameterType]] = [:]
 
         let initializers = members.compactMap { $0.decl.as(InitializerDeclSyntax.self) }
 
         if !initializers.isEmpty {
             for initializer in initializers {
-                for parameter in initializer.signature.parameterClause.parameters {
-                    guard let type = parameterType(for: parameter.type) else {
-                        continue
-                    }
-
-                    let label = parameter.firstName.tokenKind == .wildcard ? "" : parameter.firstName.text
-                    parameters[label] = type
-                }
+                let parameters = parameterTypes(of: initializer.signature.parameterClause.parameters)
+                selectors["init", default: [:]].merge(parameters) { _, new in new }
             }
         }
         else if memberwiseFallback {
-            for member in members {
-                guard let variable = member.decl.as(VariableDeclSyntax.self) else {
-                    continue
-                }
-
-                let isLet = variable.bindingSpecifier.tokenKind == .keyword(.let)
-
-                for binding in variable.bindings {
-                    // Computed properties and `let`s with a default value never appear in the
-                    // synthesized memberwise initializer, so they contribute no call label.
-                    guard
-                        let type = binding.typeAnnotation?.type,
-                        !isComputedProperty(binding.accessorBlock),
-                        !(isLet && binding.initializer != nil),
-                        let label = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
-                        let parameterType = parameterType(for: type)
-                    else {
-                        continue
-                    }
-
-                    parameters[label] = parameterType
-                }
+            let parameters = memberwiseParameters(of: members)
+            if !parameters.isEmpty {
+                selectors["init", default: [:]].merge(parameters) { _, new in new }
             }
         }
 
-        guard !parameters.isEmpty else {
+        for factory in staticFactories(of: members, returning: name) {
+            selectors[factory.selector, default: [:]].merge(factory.parameters) { _, new in new }
+        }
+
+        guard !selectors.isEmpty else {
             return
         }
 
-        typeRegistry[name, default: [:]].merge(parameters) { _, new in new }
+        mergeInitializerRegistry([name: selectors], into: &typeRegistry)
     }
 
-    /// Records an explicit-type initializer call (`Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)`)
-    /// as a pending call to resolve later. Inferred `.init(...)` calls are not recorded here —
-    /// they carry no type on their own and are captured as nested children of their enclosing call.
+    /// Records an explicit-type constructor call (`Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)`,
+    /// `Test.image(...)`) as a pending call to resolve later. Inferred leading-dot calls are not
+    /// recorded here — they carry no type on their own and are captured as nested children.
     func collectPendingInit(of node: FunctionCallExprSyntax) {
-        guard case .explicit(let typeName)? = initCalleeKind(of: node.calledExpression) else {
+        guard case .explicit(let typeName, let selector)? = initCalleeKind(of: node.calledExpression) else {
             return
         }
 
-        let pending = buildPendingInit(node, fallbackType: typeName)
+        let pending = buildPendingInit(node, fallbackType: typeName, selector: selector)
 
         if !pending.arguments.isEmpty {
             pendingInits.append(pending)
         }
     }
 
-    /// Records `.init(...)` / explicit calls found in a value assigned to a named-user-typed
-    /// context (`let x: Foo = .init(...)`, a `Foo`-returning body, a `Foo` parameter default),
-    /// pinning the inferred `.init` to the annotated type. Explicit calls are left to
+    /// Records inferred leading-dot calls (`.init(...)`, `.image(...)`) found in a value assigned to
+    /// a named-user-typed context (`let x: Foo = .init(...)`, a `Foo`/`Self`-returning body, a `Foo`
+    /// parameter default), pinning them to the resolved type. Explicit calls are left to
     /// `collectPendingInit`, which captures them via the visitor's own traversal.
     func collectNamedTypeValue(_ expression: ExprSyntax, expectedType: String) {
         for leaf in resolveTail(expression) {
@@ -91,8 +70,8 @@ extension SourceVisitor {
             }
             else if
                 let call = leaf.as(FunctionCallExprSyntax.self),
-                case .inferred? = initCalleeKind(of: call.calledExpression) {
-                let pending = buildPendingInit(call, fallbackType: expectedType)
+                case .inferred(let selector)? = initCalleeKind(of: call.calledExpression) {
+                let pending = buildPendingInit(call, fallbackType: expectedType, selector: selector)
                 if !pending.arguments.isEmpty {
                     pendingInits.append(pending)
                 }
@@ -100,8 +79,8 @@ extension SourceVisitor {
         }
     }
 
-    /// Collects named-type `.init` values returned (explicitly or implicitly) by a body,
-    /// mirroring `collectReturnedAssets` but for nested-init resolution.
+    /// Collects named-type leading-dot values returned (explicitly or implicitly) by a body,
+    /// mirroring `collectReturnedAssets` but for nested constructor resolution.
     func collectNamedTypeReturns(in statements: CodeBlockItemListSyntax, expectedType: String) {
         let visitor = ReturnVisitor(viewMode: viewMode)
         statements.forEach { visitor.walk($0) }
@@ -111,15 +90,54 @@ extension SourceVisitor {
         leaves.forEach { collectNamedTypeValue($0, expectedType: expectedType) }
     }
 
+    /// The named type an annotation/return clause refers to, resolving `Self` to the enclosing type.
+    func resolvedNamedType(for type: TypeSyntax?) -> String? {
+        guard let name = namedType(for: type) else {
+            return nil
+        }
+
+        return name == "Self" ? enclosingTypeNames.last : name
+    }
+
+    /// The concrete type a constrained protocol extension pins `Self` to via `where Self == X`
+    /// (so `.init(...)` in its method bodies resolves to `X`), or `defaultName` when unconstrained.
+    func extensionSelfType(of node: ExtensionDeclSyntax, default defaultName: String?) -> String? {
+        guard let whereClause = node.genericWhereClause else {
+            return defaultName
+        }
+
+        for requirement in whereClause.requirements {
+            guard case .sameTypeRequirement(let sameType) = requirement.requirement else {
+                continue
+            }
+
+            let left = namedType(for: sameType.leftType.as(TypeSyntax.self))
+            let right = namedType(for: sameType.rightType.as(TypeSyntax.self))
+
+            if left == "Self", let right {
+                return right
+            }
+            if right == "Self", let left {
+                return left
+            }
+        }
+
+        return defaultName
+    }
+
     // MARK: - Building
 
-    /// Builds a `PendingInitCall` from an initializer call, recursively capturing nested inferred
-    /// `.init(...)` arguments. `fallbackType` supplies the type for an inferred callee (from the
+    /// Builds a `PendingInitCall` from a constructor call, recursively capturing nested inferred
+    /// leading-dot arguments. `fallbackType` supplies the type for an inferred callee (from the
     /// enclosing parameter or annotation); an explicit callee uses its own type name.
-    private func buildPendingInit(_ call: FunctionCallExprSyntax, fallbackType: String?) -> PendingInitCall {
+    private func buildPendingInit(
+        _ call: FunctionCallExprSyntax,
+        fallbackType: String?,
+        selector: String
+    ) -> PendingInitCall {
         let typeName: String?
         switch initCalleeKind(of: call.calledExpression) {
-        case .explicit(let name): typeName = name
+        case .explicit(let name, _): typeName = name
         case .inferred, nil: typeName = fallbackType
         }
 
@@ -143,12 +161,12 @@ extension SourceVisitor {
             )
         }
 
-        return PendingInitCall(typeName: typeName, arguments: arguments)
+        return PendingInitCall(typeName: typeName, selector: selector, arguments: arguments)
     }
 
     /// Resolves an argument expression into the bare members it passes directly and the inferred
-    /// `.init(...)` calls it nests. Explicit `Type(...)` calls are intentionally skipped — the
-    /// visitor records those independently, so nesting them here would double-count.
+    /// leading-dot calls it nests. Explicit `Type(...)` / `Type.factory(...)` calls are intentionally
+    /// skipped — the visitor records those independently, so nesting them here would double-count.
     private func resolveArgumentValue(
         _ expression: ExprSyntax,
         members: inout [String],
@@ -169,8 +187,8 @@ extension SourceVisitor {
                 }
             }
             else if let call = leaf.as(FunctionCallExprSyntax.self),
-                    case .inferred? = initCalleeKind(of: call.calledExpression) {
-                nestedInits.append(buildPendingInit(call, fallbackType: nil))
+                    case .inferred(let selector)? = initCalleeKind(of: call.calledExpression) {
+                nestedInits.append(buildPendingInit(call, fallbackType: nil, selector: selector))
             }
             else if let name = innermostBareMember(of: leaf) {
                 members.append(name)
@@ -178,10 +196,91 @@ extension SourceVisitor {
         }
     }
 
+    // MARK: - Signature helpers
+
+    /// The `label → parameter type` map of a parameter list, keeping only resource/named-typed ones.
+    private func parameterTypes(of parameters: FunctionParameterListSyntax) -> [String: InitParameterType] {
+        var result: [String: InitParameterType] = [:]
+
+        for parameter in parameters {
+            guard let type = parameterType(for: parameter.type) else {
+                continue
+            }
+
+            let label = parameter.firstName.tokenKind == .wildcard ? "" : parameter.firstName.text
+            result[label] = type
+        }
+
+        return result
+    }
+
+    /// The memberwise initializer's `label → parameter type` map, from a struct's stored properties.
+    /// Computed properties and `let`s with a default value never appear in the synthesized init.
+    private func memberwiseParameters(of members: MemberBlockItemListSyntax) -> [String: InitParameterType] {
+        var result: [String: InitParameterType] = [:]
+
+        for member in members {
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else {
+                continue
+            }
+
+            let isLet = variable.bindingSpecifier.tokenKind == .keyword(.let)
+
+            for binding in variable.bindings {
+                guard
+                    let type = binding.typeAnnotation?.type,
+                    !isComputedProperty(binding.accessorBlock),
+                    !(isLet && binding.initializer != nil),
+                    let label = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+                    let parameterType = parameterType(for: type)
+                else {
+                    continue
+                }
+
+                result[label] = parameterType
+            }
+        }
+
+        return result
+    }
+
+    /// The static factory methods of a type — `static func ...(...) -> Self`/`-> Type` — as
+    /// `(selector, parameters)` pairs, so a leading-dot factory call (`.image(.frog)`) resolves
+    /// like an alternative initializer.
+    private func staticFactories(
+        of members: MemberBlockItemListSyntax,
+        returning typeName: String
+    ) -> [(selector: String, parameters: [String: InitParameterType])] {
+        var factories: [(String, [String: InitParameterType])] = []
+
+        for member in members {
+            guard
+                let function = member.decl.as(FunctionDeclSyntax.self),
+                function.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) })
+            else {
+                continue
+            }
+
+            let returnName = namedType(for: function.signature.returnClause?.type)
+            guard returnName == "Self" || returnName == typeName else {
+                continue
+            }
+
+            let parameters = parameterTypes(of: function.signature.parameterClause.parameters)
+            guard !parameters.isEmpty else {
+                continue
+            }
+
+            factories.append((function.name.text, parameters))
+        }
+
+        return factories
+    }
+
     // MARK: - Type helpers
 
     /// The `InitParameterType` for a parameter/property type: a resource kind if it resolves to
-    /// one, else the simple user-type name for nested-init resolution.
+    /// one, else the simple user-type name for nested constructor resolution.
     private func parameterType(for type: TypeSyntax?) -> InitParameterType? {
         if let kind = typedKind(for: type) {
             return .resource(kind)
@@ -211,6 +310,11 @@ extension SourceVisitor {
 
         if let array = type.as(ArrayTypeSyntax.self) {
             return namedType(for: array.element)
+        }
+
+        // `any TestProtocol` / `some TestProtocol` → the constraint's name.
+        if let someOrAny = type.as(SomeOrAnyTypeSyntax.self) {
+            return namedType(for: someOrAny.constraint)
         }
 
         if let identifier = type.as(IdentifierTypeSyntax.self) {
@@ -252,18 +356,18 @@ extension SourceVisitor {
     // MARK: - Callee classification
 
     private enum InitCalleeKind {
-        /// `Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)` — the type name is known.
-        case explicit(String)
-        /// `.init(...)` — the type is inferred from the enclosing context.
-        case inferred
+        /// `Foo(...)`, `Foo.init(...)`, `Outer.Inner(...)`, `Test.image(...)` — type and selector known.
+        case explicit(typeName: String, selector: String)
+        /// `.init(...)`, `.image(...)` — the type is inferred from context; the selector is known.
+        case inferred(selector: String)
     }
 
-    /// Classifies an initializer-call callee, or returns `nil` when the call is not an
-    /// initializer-style call we resolve (lowercase function/method calls, member chains).
+    /// Classifies a constructor-call callee, or returns `nil` when the call is not a constructor
+    /// call we resolve (plain functions, instance methods, deeper member chains).
     private func initCalleeKind(of callee: ExprSyntax) -> InitCalleeKind? {
         if let reference = callee.as(DeclReferenceExprSyntax.self) {
             let name = reference.baseName.text
-            return name.first?.isUppercase == true ? .explicit(name) : nil
+            return name.first?.isUppercase == true ? .explicit(typeName: name, selector: "init") : nil
         }
 
         guard let member = callee.as(MemberAccessExprSyntax.self) else {
@@ -272,20 +376,35 @@ extension SourceVisitor {
 
         let name = member.declName.baseName.text
 
-        if name == "init" {
-            // `Type.init(...)` carries its type in the base; bare `.init(...)` is inferred.
-            if let base = member.base, let typeName = baseTypeName(of: base) {
-                return .explicit(typeName)
+        guard let base = member.base else {
+            // Leading-dot, type inferred from context.
+            if name == "init" {
+                return .inferred(selector: "init")
             }
-            return .inferred
+            // `.image(...)` — a static factory; uppercase leading-dot calls are out of scope.
+            return name.first?.isLowercase == true ? .inferred(selector: name) : nil
         }
 
-        // `Outer.Inner(...)` — an uppercase final component is a nested type initializer;
-        // a lowercase one (`view.tint(...)`) is a method call handled elsewhere.
-        return name.first?.isUppercase == true ? .explicit(name) : nil
+        // Qualified call: the base must name a type (uppercase final component); a lowercase base
+        // (`view.tint(...)`) is an instance method handled elsewhere.
+        guard let baseName = baseTypeName(of: base), baseName.first?.isUppercase == true else {
+            return nil
+        }
+
+        if name == "init" {
+            return .explicit(typeName: baseName, selector: "init")
+        }
+
+        // `Outer.Inner(...)` — an uppercase final component is a nested type's initializer;
+        // `Test.image(...)` — a lowercase one is a static factory on the base type.
+        if name.first?.isUppercase == true {
+            return .explicit(typeName: name, selector: "init")
+        }
+
+        return .explicit(typeName: baseName, selector: name)
     }
 
-    /// The final type-name component of a `.init` base (`X` in `X.init`, `Inner` in `A.Inner.init`).
+    /// The final type-name component of a qualified base (`X` in `X.init`, `Type` in `Module.Type.f`).
     private func baseTypeName(of expression: ExprSyntax) -> String? {
         if let reference = expression.as(DeclReferenceExprSyntax.self) {
             return reference.baseName.text

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+Scopes.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+Scopes.swift
@@ -74,36 +74,56 @@ extension SourceVisitor {
     /// Resolves a type annotation/return clause to the resource kind it refers to,
     /// unwrapping `Optional`, implicitly-unwrapped optionals and `Array` (both sugar and generic forms).
     func typedKind(for type: TypeSyntax?) -> ExploreKind? {
-        guard let type else {
+        guard let leaf = unwrappedType(type) else {
             return nil
         }
 
-        if let optional = type.as(OptionalTypeSyntax.self) {
-            return typedKind(for: optional.wrappedType)
-        }
-
-        if let optional = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
-            return typedKind(for: optional.wrappedType)
-        }
-
-        if let array = type.as(ArrayTypeSyntax.self) {
-            return typedKind(for: array.element)
-        }
-
-        guard let identifier = type.as(IdentifierTypeSyntax.self) else {
-            return memberTypedKind(for: type)
+        guard let identifier = leaf.as(IdentifierTypeSyntax.self) else {
+            return memberTypedKind(for: leaf)
         }
 
         let name = identifier.name.text
 
         if name == "Array" || name == "Optional" {
-            if let argument = identifier.genericArgumentClause?.arguments.first?.argument.as(TypeSyntax.self) {
-                return typedKind(for: argument)
-            }
             return nil
         }
 
         return kind(forTypeName: name)
+    }
+
+    /// Strips `Optional` / implicitly-unwrapped-optional / `Array` / `any` / `some` sugar (and the
+    /// `Array<>` / `Optional<>` generic forms) down to the innermost type. Shared by `typedKind`
+    /// and `namedType`. A bare `Array` / `Optional` with no generic argument is returned unchanged
+    /// (it denotes neither a resource nor a user type).
+    func unwrappedType(_ type: TypeSyntax?) -> TypeSyntax? {
+        guard let type else {
+            return nil
+        }
+
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return unwrappedType(optional.wrappedType)
+        }
+
+        if let optional = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return unwrappedType(optional.wrappedType)
+        }
+
+        if let array = type.as(ArrayTypeSyntax.self) {
+            return unwrappedType(array.element)
+        }
+
+        if let someOrAny = type.as(SomeOrAnyTypeSyntax.self) {
+            return unwrappedType(someOrAny.constraint)
+        }
+
+        if
+            let identifier = type.as(IdentifierTypeSyntax.self),
+            identifier.name.text == "Array" || identifier.name.text == "Optional",
+            let argument = identifier.genericArgumentClause?.arguments.first?.argument.as(TypeSyntax.self) {
+            return unwrappedType(argument)
+        }
+
+        return type
     }
 
     /// Resolves a module-qualified type annotation like `SwiftUI.Image` or `UIKit.UIColor`.

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+TailResolution.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor+TailResolution.swift
@@ -97,6 +97,32 @@ extension SourceVisitor {
         return leaves
     }
 
+    /// Expands a value expression into the leaf expressions an argument/value position evaluates to,
+    /// flattening `resolveTail` branches, array literals, and the unfolded-ternary flat sequence
+    /// (`flag ? .a : .b`). Calls and member accesses are returned as leaves for the caller to inspect.
+    func shallowLeaves(of expression: ExprSyntax) -> [ExprSyntax] {
+        var leaves: [ExprSyntax] = []
+
+        for leaf in resolveTail(expression) {
+            if let array = leaf.as(ArrayExprSyntax.self) {
+                array.elements.forEach { leaves += shallowLeaves(of: $0.expression) }
+            }
+            else if let sequence = leaf.as(SequenceExprSyntax.self) {
+                // The parser does not fold operators, so a ternary argument arrives as a flat
+                // sequence whose `then` branch hides inside an UnresolvedTernaryExprSyntax element.
+                for element in sequence.elements {
+                    let unwrapped = element.as(UnresolvedTernaryExprSyntax.self)?.thenExpression ?? element
+                    leaves += shallowLeaves(of: unwrapped)
+                }
+            }
+            else {
+                leaves.append(leaf)
+            }
+        }
+
+        return leaves
+    }
+
     /// `.brand` → "brand"; `.brand.opacity(0.5)` → "brand"; `VStack(...)` / `Color(.x)` /
     /// literals → nil (a call only counts when its callee chain is rooted in a bare member).
     func innermostBareMember(of expression: ExprSyntax) -> String? {

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
@@ -12,14 +12,18 @@ final class SourceVisitor: SyntaxVisitor {
 
     private(set) var usages: [ExploreUsage] = []
 
-    /// User-type initializer signatures declared in this file: `typeName → (label → parameter type)`.
+    /// User-type constructor signatures declared in this file: `typeName → selector → (label → type)`.
     /// Aggregated across files and used to resolve `pendingInits`. Mutated from the
     /// `SourceVisitor+InitArguments` extension, so it carries an internal (not private) setter.
-    var typeRegistry: [String: [String: InitParameterType]] = [:]
+    var typeRegistry: InitializerRegistry = [:]
 
-    /// Explicit-type initializer call sites whose arguments may carry resources, resolved against
+    /// Explicit-type constructor call sites whose arguments may carry resources, resolved against
     /// `typeRegistry` once every file has contributed.
     var pendingInits: [PendingInitCall] = []
+
+    /// Stack of enclosing type names (struct/class/actor/extension), used to resolve `Self` in a
+    /// return clause back to the concrete type so `static func make() -> Self { .init(...) }` resolves.
+    var enclosingTypeNames: [String] = []
 
     /// Lexical scope stack of resource-typed variables, used to attribute assignments
     /// (`local = .asset`) to the right kind. The root scope holds file/type-level names;
@@ -115,7 +119,7 @@ final class SourceVisitor: SyntaxVisitor {
                     collectReturnedAssets(in: statements, with: kind)
                 }
             }
-            else if let typeName = namedType(for: type) {
+            else if let typeName = resolvedNamedType(for: type) {
                 if let value = binding.initializer?.value {
                     collectNamedTypeValue(value, expectedType: typeName)
                 }
@@ -139,7 +143,7 @@ final class SourceVisitor: SyntaxVisitor {
         if let kind = typedKind(for: returnType), let body = node.body {
             collectReturnedAssets(in: body.statements, with: kind)
         }
-        else if let typeName = namedType(for: returnType), let body = node.body {
+        else if let typeName = resolvedNamedType(for: returnType), let body = node.body {
             collectNamedTypeReturns(in: body.statements, expectedType: typeName)
         }
 
@@ -158,7 +162,7 @@ final class SourceVisitor: SyntaxVisitor {
         if let kind = typedKind(for: returnType) {
             collectReturnedAssets(in: node.statements, with: kind)
         }
-        else if let typeName = namedType(for: returnType) {
+        else if let typeName = resolvedNamedType(for: returnType) {
             collectNamedTypeReturns(in: node.statements, expectedType: typeName)
         }
 
@@ -214,7 +218,7 @@ final class SourceVisitor: SyntaxVisitor {
             if let kind = typedKind(for: node.returnClause.type) {
                 collectReturnedAssets(in: statements, with: kind)
             }
-            else if let typeName = namedType(for: node.returnClause.type) {
+            else if let typeName = resolvedNamedType(for: node.returnClause.type) {
                 collectNamedTypeReturns(in: statements, expectedType: typeName)
             }
         }
@@ -237,22 +241,26 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
+        enclosingTypeNames.append(node.name.text)
         registerType(named: node.name.text, members: node.memberBlock.members, memberwiseFallback: false)
         return .visitChildren
     }
 
     override func visitPost(_ node: ClassDeclSyntax) {
         popScope()
+        enclosingTypeNames.removeLast()
     }
 
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
+        enclosingTypeNames.append(node.name.text)
         registerType(named: node.name.text, members: node.memberBlock.members, memberwiseFallback: true)
         return .visitChildren
     }
 
     override func visitPost(_ node: StructDeclSyntax) {
         popScope()
+        enclosingTypeNames.removeLast()
     }
 
     override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -266,21 +274,45 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
+        enclosingTypeNames.append(node.name.text)
         registerType(named: node.name.text, members: node.memberBlock.members, memberwiseFallback: false)
         return .visitChildren
     }
 
     override func visitPost(_ node: ActorDeclSyntax) {
         popScope()
+        enclosingTypeNames.removeLast()
     }
 
     override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
+
+        // Register factories under the extended type (so a call on `any P` resolves), but resolve
+        // `Self` in their bodies to the constrained type from `where Self == X` when present.
+        let extendedType = namedType(for: node.extendedType)
+        enclosingTypeNames.append(extensionSelfType(of: node, default: extendedType) ?? "")
+
+        if let extendedType {
+            registerType(named: extendedType, members: node.memberBlock.members, memberwiseFallback: false)
+        }
+
         return .visitChildren
     }
 
     override func visitPost(_ node: ExtensionDeclSyntax) {
         popScope()
+        enclosingTypeNames.removeLast()
+    }
+
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+        pushScope()
+        enclosingTypeNames.append(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ProtocolDeclSyntax) {
+        popScope()
+        enclosingTypeNames.removeLast()
     }
 }
 
@@ -451,7 +483,7 @@ extension SourceVisitor {
             if let kind = typedKind(for: parameter.type) {
                 collectValue(value, with: kind)
             }
-            else if let typeName = namedType(for: parameter.type) {
+            else if let typeName = resolvedNamedType(for: parameter.type) {
                 collectNamedTypeValue(value, expectedType: typeName)
             }
         }

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
@@ -12,6 +12,15 @@ final class SourceVisitor: SyntaxVisitor {
 
     private(set) var usages: [ExploreUsage] = []
 
+    /// User-type initializer signatures declared in this file: `typeName → (label → parameter type)`.
+    /// Aggregated across files and used to resolve `pendingInits`. Mutated from the
+    /// `SourceVisitor+InitArguments` extension, so it carries an internal (not private) setter.
+    var typeRegistry: [String: [String: InitParameterType]] = [:]
+
+    /// Explicit-type initializer call sites whose arguments may carry resources, resolved against
+    /// `typeRegistry` once every file has contributed.
+    var pendingInits: [PendingInitCall] = []
+
     /// Lexical scope stack of resource-typed variables, used to attribute assignments
     /// (`local = .asset`) to the right kind. The root scope holds file/type-level names;
     /// a new scope is pushed per function-like / type body so a local in one scope does
@@ -60,6 +69,7 @@ final class SourceVisitor: SyntaxVisitor {
         usages.append(contentsOf: newUsages)
 
         collectMemberCallArguments(of: node)
+        collectPendingInit(of: node)
 
         return super.visit(node)
     }
@@ -90,20 +100,29 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
         for binding in node.bindings {
-            guard let kind = typedKind(for: binding.typeAnnotation?.type) else {
-                continue
-            }
+            let type = binding.typeAnnotation?.type
 
-            if let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
-                declareTypedVariable(name, kind)
-            }
+            if let kind = typedKind(for: type) {
+                if let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
+                    declareTypedVariable(name, kind)
+                }
 
-            if let value = binding.initializer?.value {
-                collectValue(value, with: kind)
-            }
+                if let value = binding.initializer?.value {
+                    collectValue(value, with: kind)
+                }
 
-            if let statements = getterStatements(of: binding.accessorBlock) {
-                collectReturnedAssets(in: statements, with: kind)
+                if let statements = getterStatements(of: binding.accessorBlock) {
+                    collectReturnedAssets(in: statements, with: kind)
+                }
+            }
+            else if let typeName = namedType(for: type) {
+                if let value = binding.initializer?.value {
+                    collectNamedTypeValue(value, expectedType: typeName)
+                }
+
+                if let statements = getterStatements(of: binding.accessorBlock) {
+                    collectNamedTypeReturns(in: statements, expectedType: typeName)
+                }
             }
         }
 
@@ -115,8 +134,13 @@ final class SourceVisitor: SyntaxVisitor {
 
         collectParameterDefaults(node.signature.parameterClause.parameters)
 
-        if let kind = typedKind(for: node.signature.returnClause?.type), let body = node.body {
+        let returnType = node.signature.returnClause?.type
+
+        if let kind = typedKind(for: returnType), let body = node.body {
             collectReturnedAssets(in: body.statements, with: kind)
+        }
+        else if let typeName = namedType(for: returnType), let body = node.body {
+            collectNamedTypeReturns(in: body.statements, expectedType: typeName)
         }
 
         return .visitChildren
@@ -129,8 +153,13 @@ final class SourceVisitor: SyntaxVisitor {
     override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
 
-        if let kind = typedKind(for: node.signature?.returnClause?.type) {
+        let returnType = node.signature?.returnClause?.type
+
+        if let kind = typedKind(for: returnType) {
             collectReturnedAssets(in: node.statements, with: kind)
+        }
+        else if let typeName = namedType(for: returnType) {
+            collectNamedTypeReturns(in: node.statements, expectedType: typeName)
         }
 
         return .visitChildren
@@ -181,10 +210,13 @@ final class SourceVisitor: SyntaxVisitor {
 
         collectParameterDefaults(node.parameterClause.parameters)
 
-        if
-            let kind = typedKind(for: node.returnClause.type),
-            let statements = getterStatements(of: node.accessorBlock) {
-            collectReturnedAssets(in: statements, with: kind)
+        if let statements = getterStatements(of: node.accessorBlock) {
+            if let kind = typedKind(for: node.returnClause.type) {
+                collectReturnedAssets(in: statements, with: kind)
+            }
+            else if let typeName = namedType(for: node.returnClause.type) {
+                collectNamedTypeReturns(in: statements, expectedType: typeName)
+            }
         }
 
         return .visitChildren
@@ -205,6 +237,7 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
+        registerType(named: node.name.text, members: node.memberBlock.members, memberwiseFallback: false)
         return .visitChildren
     }
 
@@ -214,6 +247,7 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
+        registerType(named: node.name.text, members: node.memberBlock.members, memberwiseFallback: true)
         return .visitChildren
     }
 
@@ -232,6 +266,7 @@ final class SourceVisitor: SyntaxVisitor {
 
     override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
         pushScope()
+        registerType(named: node.name.text, members: node.memberBlock.members, memberwiseFallback: false)
         return .visitChildren
     }
 
@@ -409,8 +444,15 @@ extension SourceVisitor {
     /// e.g. `func makeBadge(icon: UIImage = .star)`.
     private func collectParameterDefaults(_ parameters: FunctionParameterListSyntax) {
         for parameter in parameters {
-            if let kind = typedKind(for: parameter.type), let value = parameter.defaultValue?.value {
+            guard let value = parameter.defaultValue?.value else {
+                continue
+            }
+
+            if let kind = typedKind(for: parameter.type) {
                 collectValue(value, with: kind)
+            }
+            else if let typeName = namedType(for: parameter.type) {
+                collectNamedTypeValue(value, expectedType: typeName)
             }
         }
     }

--- a/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
+++ b/Sources/SURCore/Parsers/SwiftVisitors/SourceVisitor.swift
@@ -23,7 +23,9 @@ final class SourceVisitor: SyntaxVisitor {
 
     /// Stack of enclosing type names (struct/class/actor/extension), used to resolve `Self` in a
     /// return clause back to the concrete type so `static func make() -> Self { .init(...) }` resolves.
-    var enclosingTypeNames: [String] = []
+    /// An entry is `nil` when the enclosing type's name can't be resolved, so `Self` there resolves
+    /// to nothing rather than colliding on a shared empty-string sentinel.
+    var enclosingTypeNames: [String?] = []
 
     /// Lexical scope stack of resource-typed variables, used to attribute assignments
     /// (`local = .asset`) to the right kind. The root scope holds file/type-level names;
@@ -290,7 +292,7 @@ final class SourceVisitor: SyntaxVisitor {
         // Register factories under the extended type (so a call on `any P` resolves), but resolve
         // `Self` in their bodies to the constrained type from `where Self == X` when present.
         let extendedType = namedType(for: node.extendedType)
-        enclosingTypeNames.append(extensionSelfType(of: node, default: extendedType) ?? "")
+        enclosingTypeNames.append(extensionSelfType(of: node, default: extendedType))
 
         if let extendedType {
             registerType(named: extendedType, members: node.memberBlock.members, memberwiseFallback: false)
@@ -317,66 +319,6 @@ final class SourceVisitor: SyntaxVisitor {
 }
 
 extension SourceVisitor {
-    private func findR(
-        in node: DeclReferenceExprSyntax,
-        with kind: ExploreKind
-    ) -> ExploreUsage? {
-        guard node.baseName.text == "R" else {
-            return nil
-        }
-        
-        let members = members(in: node).dropFirst()
-        
-        guard members.first == kind.rawValue, let name = members.dropFirst().first else {
-            return nil
-        }
-        
-        return .rswift(name, kind)
-    }
-    
-    private func findGeneratedAsset(
-        in node: DeclReferenceExprSyntax,
-        with kind: ExploreKind
-    ) -> ExploreUsage? {
-        guard Self.generatedClassKinds[node.baseName.text] == kind else {
-            return nil
-        }
-
-        if let call = initializerCall(of: node) {
-            // collectValue resolves ternary / if / switch branches before recording, so
-            // `UIImage(resource: flag ? .a : .b)` records both assets. Usages are appended
-            // directly; a DeclRef has no children worth skipping, so returning nil is fine.
-            if call.arguments.count == 1, let argument = call.arguments.first {
-                collectValue(argument.expression, with: kind)
-            }
-
-            return nil
-        }
-        else {
-            var members = members(in: node).array()
-
-            if let first = members.first, Self.assetModules.contains(first) {
-                members.removeFirst()
-            }
-
-            // `members.first == baseName` rejects chains rooted in an unknown namespace:
-            // in `MyKit.Image.star` the first member is `MyKit`, so `Image` there is some
-            // custom type, not the SwiftUI one.
-            guard members.count >= 2, members.first == node.baseName.text else {
-                return nil
-            }
-
-            let name = members[1]
-
-            // Asset symbols can never be named `init`; `UIImage.init(named:)` is not an asset.
-            guard name != "init" else {
-                return nil
-            }
-
-            return .generated(name, kind)
-        }
-    }
-
     /// Records bare members passed to known color/image-taking member calls. Only unlabeled
     /// arguments and arguments labeled `color` are collected, so control labels
     /// (`for:`, `alignment:`, `in:`, …) are never mistaken for assets.
@@ -402,62 +344,11 @@ extension SourceVisitor {
     /// `[.a, .b]`, `flag ? .a : .b`) WITHOUT the deep subtree walk used for typed contexts —
     /// view-builder arguments like `.background(VStack { ... })` must contribute nothing.
     private func collectShallowBareMembers(in expression: ExprSyntax, with kind: ExploreKind) {
-        for leaf in resolveTail(expression) {
-            if let array = leaf.as(ArrayExprSyntax.self) {
-                array.elements.forEach { collectShallowBareMembers(in: $0.expression, with: kind) }
-            }
-            else if let sequence = leaf.as(SequenceExprSyntax.self) {
-                // The parser does not fold operators, so a ternary argument arrives as a flat
-                // sequence: `flag ? .a : .b` → [flag, UnresolvedTernary(.a), .b]. Collect from
-                // each operand; the unresolved-ternary element carries the `then` branch.
-                for element in sequence.elements {
-                    let unwrapped = element.as(UnresolvedTernaryExprSyntax.self)?.thenExpression ?? element
-                    collectShallowBareMembers(in: unwrapped, with: kind)
-                }
-            }
-            else if let name = innermostBareMember(of: leaf) {
+        for leaf in shallowLeaves(of: expression) {
+            if let name = innermostBareMember(of: leaf) {
                 usages.append(.generated(name, kind))
             }
         }
-    }
-
-    /// The call node when `node` is the called type of an initializer call — either plain
-    /// `UIImage(...)` or module-qualified `SwiftUI.Image(...)`.
-    private func initializerCall(of node: DeclReferenceExprSyntax) -> FunctionCallExprSyntax? {
-        if let call = node.parent?.as(FunctionCallExprSyntax.self) {
-            return call
-        }
-
-        guard
-            let member = node.parent?.as(MemberAccessExprSyntax.self),
-            member.declName.id == node.id,
-            let base = member.base?.as(DeclReferenceExprSyntax.self),
-            Self.assetModules.contains(base.baseName.text)
-        else {
-            return nil
-        }
-
-        return member.parent?.as(FunctionCallExprSyntax.self)
-    }
-    
-    private func members(in node: DeclReferenceExprSyntax) -> some RandomAccessCollection<String> {
-        guard let parent = node.parent?.as(MemberAccessExprSyntax.self) else {
-            return []
-        }
-        
-        let usage = sequence(first: parent) { $0.parent?.as(MemberAccessExprSyntax.self) }
-            .array()
-            .last
-        
-        guard let usage else {
-            return []
-        }
-        
-        let visitor = MemberVisitor(viewMode: viewMode)
-
-        visitor.walk(usage)
-
-        return visitor.members
     }
 
     /// Collects every asset returned by a body — both explicit `return`s (anywhere in the body,
@@ -490,7 +381,7 @@ extension SourceVisitor {
     }
 
     /// Resolves a value expression (initializer / assignment RHS) and records its bare members.
-    private func collectValue(_ expression: ExprSyntax, with kind: ExploreKind) {
+    func collectValue(_ expression: ExprSyntax, with kind: ExploreKind) {
         resolveTail(expression).forEach { collectBareMembers(in: $0, with: kind) }
     }
 

--- a/Tests/SURCoreTests/ExplorerIntegrationTests.swift
+++ b/Tests/SURCoreTests/ExplorerIntegrationTests.swift
@@ -134,6 +134,85 @@ struct ExplorerIntegrationTests {
         #expect(unused == ["lonely"])
     }
 
+    @Test("Counts an image passed to a struct init defined in another file")
+    func crossFileStructInitUsage() async throws {
+        let fixture = try FixtureProject()
+        defer { fixture.remove() }
+
+        try fixture.addAssetCatalog("Assets.xcassets", imageSets: ["star", "lonely"])
+        try fixture.addSource("Style.swift", """
+        struct CardStyle { let icon: ImageResource }
+        """)
+        try fixture.addSource("Use.swift", """
+        let card = CardStyle(icon: .star)
+        """)
+        try fixture.write(targets: [
+            .init(name: "App", sources: ["Style.swift", "Use.swift"], resources: ["Assets.xcassets"]),
+        ])
+
+        let unused = try await unusedNames(in: fixture, target: "App")
+        #expect(unused == ["lonely"])
+    }
+
+    @Test("Counts an image nested in an inferred .init across files")
+    func crossFileNestedInitUsage() async throws {
+        let fixture = try FixtureProject()
+        defer { fixture.remove() }
+
+        try fixture.addAssetCatalog("Assets.xcassets", imageSets: ["cat", "lonely"])
+        try fixture.addSource("Models.swift", """
+        struct Test { let image: ImageResource; let text: String }
+        struct Foo { let test: Test }
+        """)
+        try fixture.addSource("Use.swift", """
+        let foo = Foo(test: .init(image: .cat, text: "AAA"))
+        """)
+        try fixture.write(targets: [
+            .init(name: "App", sources: ["Models.swift", "Use.swift"], resources: ["Assets.xcassets"]),
+        ])
+
+        let unused = try await unusedNames(in: fixture, target: "App")
+        #expect(unused == ["lonely"])
+    }
+
+    @Test("Counts a color passed to a struct init across files")
+    func crossFileColorInitUsage() async throws {
+        let fixture = try FixtureProject()
+        defer { fixture.remove() }
+
+        try fixture.addAssetCatalog("Assets.xcassets", colorSets: ["brand", "unusedColor"])
+        try fixture.addSource("Theme.swift", """
+        struct Theme { let bg: ColorResource; let name: String }
+        """)
+        try fixture.addSource("Use.swift", """
+        let theme = Theme(bg: .brand, name: "x")
+        """)
+        try fixture.write(targets: [
+            .init(name: "App", sources: ["Theme.swift", "Use.swift"], resources: ["Assets.xcassets"]),
+        ])
+
+        let unused = try await unusedNames(in: fixture, target: "App")
+        #expect(unused == ["unusedColor"])
+    }
+
+    @Test("Does not count a bare member passed to a String parameter")
+    func stringParameterDoesNotCount() async throws {
+        let fixture = try FixtureProject()
+        defer { fixture.remove() }
+
+        try fixture.addAssetCatalog("Assets.xcassets", imageSets: ["lonely"])
+        try fixture.addSource("Main.swift", """
+        struct Label { let text: String }
+        let label = Label(text: .lonely)
+        """)
+        try fixture.write(targets: [
+            .init(name: "App", sources: ["Main.swift"], resources: ["Assets.xcassets"]),
+        ])
+
+        let unused = try await unusedNames(in: fixture, target: "App")
+        #expect(unused == ["lonely"])
+    }
+
     @Test("Reports an unused loose image file")
     func looseImageReported() async throws {
         let fixture = try FixtureProject()

--- a/Tests/SURCoreTests/ExplorerIntegrationTests.swift
+++ b/Tests/SURCoreTests/ExplorerIntegrationTests.swift
@@ -195,6 +195,87 @@ struct ExplorerIntegrationTests {
         #expect(unused == ["unusedColor"])
     }
 
+    @Test("Counts images via static factories and factory bodies across files")
+    func crossFileStaticFactoryUsage() async throws {
+        let fixture = try FixtureProject()
+        defer { fixture.remove() }
+
+        try fixture.addAssetCatalog("Assets.xcassets", imageSets: ["dog", "frog", "lonely"])
+        try fixture.addSource("Test.swift", """
+        struct Test {
+            let image: ImageResource
+            let text: String
+        }
+
+        extension Test {
+            static func image(_ image: ImageResource) -> Self {
+                .init(image: image, text: "Default")
+            }
+
+            static func text(_ text: String) -> Self {
+                .init(image: .dog, text: text)
+            }
+        }
+
+        struct Foo {
+            let test: Test
+        }
+        """)
+        try fixture.addSource("Use.swift", """
+        let foo = Foo(test: .image(.frog))
+        let bar = Foo(test: .text("bar"))
+        """)
+        try fixture.write(targets: [
+            .init(name: "App", sources: ["Test.swift", "Use.swift"], resources: ["Assets.xcassets"]),
+        ])
+
+        let unused = try await unusedNames(in: fixture, target: "App")
+        #expect(unused == ["lonely"])
+    }
+
+    @Test("Counts images via a constrained protocol extension across files")
+    func crossFileProtocolFactoryUsage() async throws {
+        let fixture = try FixtureProject()
+        defer { fixture.remove() }
+
+        try fixture.addAssetCatalog("Assets.xcassets", imageSets: ["dog", "frog", "lonely"])
+        try fixture.addSource("Test.swift", """
+        protocol TestProtocol {
+            var image: ImageResource { get }
+            var text: String { get }
+        }
+
+        struct Test: TestProtocol {
+            let image: ImageResource
+            let text: String
+        }
+
+        extension TestProtocol where Self == Test {
+            static func image(_ image: ImageResource) -> Self {
+                .init(image: image, text: "Default")
+            }
+
+            static func text(_ text: String) -> Self {
+                .init(image: .dog, text: text)
+            }
+        }
+
+        struct Foo {
+            let test: any TestProtocol
+        }
+        """)
+        try fixture.addSource("Use.swift", """
+        let foo = Foo(test: .image(.frog))
+        let bar = Foo(test: .text("bar"))
+        """)
+        try fixture.write(targets: [
+            .init(name: "App", sources: ["Test.swift", "Use.swift"], resources: ["Assets.xcassets"]),
+        ])
+
+        let unused = try await unusedNames(in: fixture, target: "App")
+        #expect(unused == ["lonely"])
+    }
+
     @Test("Does not count a bare member passed to a String parameter")
     func stringParameterDoesNotCount() async throws {
         let fixture = try FixtureProject()

--- a/Tests/SURCoreTests/InitArgumentUsageTests.swift
+++ b/Tests/SURCoreTests/InitArgumentUsageTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+@testable import SURCore
+
+@Suite("Resource usage through struct/class initializer arguments")
+struct InitArgumentUsageTests {
+    private let kinds: Set<ExploreKind> = [.image, .color]
+
+    /// Parses a single source, then resolves its pending initializer calls against its own
+    /// declared registry — mirroring what `Explorer` does across files for one file's worth.
+    private func usages(_ source: String) -> [ExploreUsage] {
+        let result = SwiftParser(showWarnings: false, kinds: kinds).parseDetailed(source: source)
+        return InitArgumentResolver(typeRegistry: result.typeRegistry, kinds: kinds).resolve(result.pendingInits)
+    }
+
+    private func images(_ source: String) -> [String] {
+        usages(source).compactMap {
+            if case let .generated(identifier, .image) = $0 { return identifier }
+            return nil
+        }
+    }
+
+    private func colors(_ source: String) -> [String] {
+        usages(source).compactMap {
+            if case let .generated(identifier, .color) = $0 { return identifier }
+            return nil
+        }
+    }
+
+    // MARK: - Memberwise initializer
+
+    @Test("Resolves a resource passed to a struct's memberwise init")
+    func memberwiseInit() {
+        let source = """
+        struct S { let icon: ImageResource }
+        let x = S(icon: .star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    @Test("Resolves image and color args, ignoring a String arg")
+    func mixedArguments() {
+        let source = """
+        struct S { let icon: ImageResource; let bg: ColorResource; let title: String }
+        let x = S(icon: .star, bg: .brand, title: "Hi")
+        """
+        #expect(images(source) == ["star"])
+        #expect(colors(source) == ["brand"])
+    }
+
+    @Test("Resolves an array-typed resource parameter")
+    func arrayParameter() {
+        let source = """
+        struct S { let icons: [ImageResource] }
+        let x = S(icons: [.a, .b])
+        """
+        #expect(Set(images(source)) == ["a", "b"])
+    }
+
+    @Test("Resolves an optional-typed resource parameter")
+    func optionalParameter() {
+        let source = """
+        struct S { let icon: ImageResource? }
+        let x = S(icon: .star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    @Test("Resolves both branches of a ternary argument")
+    func ternaryArgument() {
+        let source = """
+        struct S { let icon: ImageResource }
+        let x = S(icon: flag ? .a : .b)
+        """
+        #expect(Set(images(source)) == ["a", "b"])
+    }
+
+    // MARK: - Explicit initializers
+
+    @Test("Resolves an explicit init's external parameter label")
+    func explicitInitLabel() {
+        let source = """
+        struct S { let stored: ImageResource; init(pic: ImageResource) { stored = pic } }
+        let x = S(pic: .star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    @Test("Resolves a positional (unlabeled) init parameter")
+    func positionalParameter() {
+        let source = """
+        struct S { let stored: ImageResource; init(_ icon: ImageResource) { stored = icon } }
+        let x = S(.star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    @Test("Resolves a class initializer argument")
+    func classInit() {
+        let source = """
+        final class S { let icon: ImageResource; init(icon: ImageResource) { self.icon = icon } }
+        let x = S(icon: .star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    @Test("Resolves an actor initializer argument")
+    func actorInit() {
+        let source = """
+        actor S { let icon: ImageResource; init(icon: ImageResource) { self.icon = icon } }
+        let x = S(icon: .star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    // MARK: - Nested / inferred initializers
+
+    @Test("Resolves the user's nested inferred .init example")
+    func nestedInferredInit() {
+        let source = """
+        struct Test { let image: ImageResource; let text: String }
+        struct Foo { let test: Test }
+        let foo = Foo(test: .init(image: .cat, text: "AAA"))
+        """
+        #expect(images(source) == ["cat"])
+    }
+
+    @Test("Resolves a nested explicit-type init argument")
+    func nestedExplicitInit() {
+        let source = """
+        struct Test { let image: ImageResource }
+        struct Foo { let test: Test }
+        let foo = Foo(test: Test(image: .cat))
+        """
+        #expect(images(source) == ["cat"])
+    }
+
+    @Test("Resolves .init through a typed binding annotation")
+    func typedContextInit() {
+        let source = """
+        struct Test { let image: ImageResource }
+        struct Foo { let test: Test }
+        let x: Foo = .init(test: .init(image: .cat))
+        """
+        #expect(images(source) == ["cat"])
+    }
+
+    @Test("Resolves a nested-type initializer (Outer.Inner)")
+    func nestedTypeInit() {
+        let source = """
+        struct Outer { struct Inner { let icon: ImageResource } }
+        let x = Outer.Inner(icon: .star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    // MARK: - Exclusions
+
+    @Test("A computed property is not treated as a memberwise label")
+    func computedPropertyExcluded() {
+        let source = """
+        struct S { let icon: ImageResource; var derived: ImageResource { .x } }
+        let s = S(derived: .y)
+        """
+        #expect(images(source).isEmpty)
+    }
+
+    @Test("A `let` with a default value is absent from the memberwise init")
+    func letWithDefaultExcluded() {
+        let source = """
+        struct S { let b: ImageResource = .def }
+        let s = S(b: .star)
+        """
+        #expect(images(source).isEmpty)
+    }
+
+    // MARK: - Negatives
+
+    @Test("A non-resource type's init resolves nothing")
+    func nonResourceInit() {
+        let source = """
+        struct Point { let x: Int; let y: Int }
+        let p = Point(x: 1, y: 2)
+        """
+        #expect(usages(source).isEmpty)
+    }
+
+    @Test("A bare member in a String argument is not recorded")
+    func stringArgumentIgnored() {
+        let source = """
+        struct Label { let text: String }
+        let l = Label(text: .lonely)
+        """
+        #expect(usages(source).isEmpty)
+    }
+
+    @Test("A trailing closure argument contributes nothing")
+    func trailingClosureIgnored() {
+        let source = """
+        struct S { let make: () -> Void }
+        let x = S { print("hi") }
+        """
+        #expect(usages(source).isEmpty)
+    }
+}

--- a/Tests/SURCoreTests/InitArgumentUsageTests.swift
+++ b/Tests/SURCoreTests/InitArgumentUsageTests.swift
@@ -15,16 +15,19 @@ struct InitArgumentUsageTests {
     }
 
     private func images(_ source: String) -> [String] {
-        usages(source).compactMap {
-            if case let .generated(identifier, .image) = $0 { return identifier }
-            return nil
-        }
+        identifiers(in: source, of: .image)
     }
 
     private func colors(_ source: String) -> [String] {
-        usages(source).compactMap {
-            if case let .generated(identifier, .color) = $0 { return identifier }
-            return nil
+        identifiers(in: source, of: .color)
+    }
+
+    private func identifiers(in source: String, of kind: ExploreKind) -> [String] {
+        usages(source).compactMap { usage in
+            guard case let .generated(identifier, usageKind) = usage, usageKind == kind else {
+                return nil
+            }
+            return identifier
         }
     }
 
@@ -92,6 +95,25 @@ struct InitArgumentUsageTests {
         let source = """
         struct S { let stored: ImageResource; init(_ icon: ImageResource) { stored = icon } }
         let x = S(.star)
+        """
+        #expect(images(source) == ["star"])
+    }
+
+    @Test("Distinguishes multiple positional parameters of different kinds")
+    func multiplePositionalParameters() {
+        let source = """
+        struct S { let img: ImageResource; let col: ColorResource; init(_ img: ImageResource, _ col: ColorResource) { self.img = img; self.col = col } }
+        let x = S(.cat, .brand)
+        """
+        #expect(images(source) == ["cat"])
+        #expect(colors(source) == ["brand"])
+    }
+
+    @Test("Resolves a type whose name has a leading underscore")
+    func underscorePrefixedType() {
+        let source = """
+        struct _InternalStyle { let icon: ImageResource }
+        let x = _InternalStyle(icon: .star)
         """
         #expect(images(source) == ["star"])
     }

--- a/Tests/SURCoreTests/InitArgumentUsageTests.swift
+++ b/Tests/SURCoreTests/InitArgumentUsageTests.swift
@@ -155,6 +155,93 @@ struct InitArgumentUsageTests {
         #expect(images(source) == ["star"])
     }
 
+    // MARK: - Static factory methods
+
+    @Test("Resolves a resource passed to an inferred static factory")
+    func staticFactoryArgument() {
+        let source = """
+        struct Test { let image: ImageResource; let text: String }
+        extension Test {
+            static func image(_ image: ImageResource) -> Self { .init(image: image, text: "Default") }
+        }
+        struct Foo { let test: Test }
+        let foo = Foo(test: .image(.frog))
+        """
+        #expect(images(source) == ["frog"])
+    }
+
+    @Test("Resolves a literal inside a Self-returning factory body")
+    func factoryBodyLiteral() {
+        let source = """
+        struct Test { let image: ImageResource; let text: String }
+        extension Test {
+            static func text(_ text: String) -> Self { .init(image: .dog, text: text) }
+        }
+        """
+        #expect(images(source) == ["dog"])
+    }
+
+    @Test("Resolves the full static-factory example to dog and frog")
+    func staticFactoryFullExample() {
+        let source = """
+        struct Test {
+            let image: ImageResource
+            let text: String
+        }
+
+        extension Test {
+            static func image(_ image: ImageResource) -> Self {
+                .init(image: image, text: "Default")
+            }
+
+            static func text(_ text: String) -> Self {
+                .init(image: .dog, text: text)
+            }
+        }
+
+        struct Foo {
+            let test: Test
+        }
+
+        let foo = Foo(test: .image(.frog))
+        let bar = Foo(test: .text("bar"))
+        """
+        #expect(Set(images(source)) == ["dog", "frog"])
+    }
+
+    @Test("Resolves factories from a constrained protocol extension via an existential")
+    func protocolExtensionFactories() {
+        let source = """
+        protocol TestProtocol {
+            var image: ImageResource { get }
+            var text: String { get }
+        }
+
+        struct Test: TestProtocol {
+            let image: ImageResource
+            let text: String
+        }
+
+        extension TestProtocol where Self == Test {
+            static func image(_ image: ImageResource) -> Self {
+                .init(image: image, text: "Default")
+            }
+
+            static func text(_ text: String) -> Self {
+                .init(image: .dog, text: text)
+            }
+        }
+
+        struct Foo {
+            let test: any TestProtocol
+        }
+
+        let foo = Foo(test: .image(.frog))
+        let bar = Foo(test: .text("bar"))
+        """
+        #expect(Set(images(source)) == ["dog", "frog"])
+    }
+
     // MARK: - Exclusions
 
     @Test("A computed property is not treated as a memberwise label")


### PR DESCRIPTION
This pull request introduces a cross-file mechanism for resolving asset usages passed via user-defined type initializers in Swift code. It does so by tracking initializer signatures and call sites across files, then resolving them after all files are parsed. The changes also refactor and extend the parsing logic to support this, making asset detection more robust for nested and inferred `.init(...)` calls.

The most important changes are:

**Cross-file initializer resolution and registry:**
* Added a per-target `InitializerRegistry` and `pendingInits` collection to `Explorer`, which aggregate user-type initializer signatures and call sites across files, and are resolved just before analysis. (`Explorer.swift`) [[1]](diffhunk://#diff-658e86db31d7e034ac1af893a9ccc2e9963f50c774f3307740e14ac249427ac4R22-R27) [[2]](diffhunk://#diff-658e86db31d7e034ac1af893a9ccc2e9963f50c774f3307740e14ac249427ac4R160-R161) [[3]](diffhunk://#diff-658e86db31d7e034ac1af893a9ccc2e9963f50c774f3307740e14ac249427ac4R178-R179)
* Introduced the `InitArgumentResolver` utility, which resolves collected initializer calls against the aggregated registry, supporting nested and type-inferred `.init(...)` calls. (`InitArgumentResolver.swift`)
* Defined new types for representing initializer parameter types, registries, pending calls, and parse results, and provided a merge function for combining registries across files. (`InitParameterType.swift`)

**Parser and visitor refactoring:**
* Refactored `SwiftParser` to return a detailed `SwiftParseResult` (including usages, type registry, and pending inits) from each file, and updated `Explorer` to aggregate and process these results. (`SwiftParser.swift`, `Explorer.swift`) [[1]](diffhunk://#diff-bef5236b4e1d86f8038ffd360215585b787baa4917e73cf214c9942b0f9e7e60L26-R48) [[2]](diffhunk://#diff-bef5236b4e1d86f8038ffd360215585b787baa4917e73cf214c9942b0f9e7e60L44-R63) [[3]](diffhunk://#diff-658e86db31d7e034ac1af893a9ccc2e9963f50c774f3307740e14ac249427ac4L321-R331) [[4]](diffhunk://#diff-658e86db31d7e034ac1af893a9ccc2e9963f50c774f3307740e14ac249427ac4L334-R370)
* Extended `SourceVisitor` to collect and track initializer signatures, pending initializer call sites, and enclosing type names, and to properly register types and handle nested/extension/protocol contexts. (`SourceVisitor.swift`) [[1]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R15-R27) [[2]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R76) [[3]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R244-R263) [[4]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R277-R315)

**Improved asset usage detection for user types:**
* Updated variable, function, and closure return type handling to support user types (not just resource types), so that asset usages can be traced through user-defined initializers and returned values. (`SourceVisitor.swift`) [[1]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543L93-R109) [[2]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543R122-R131) [[3]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543L118-R148) [[4]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543L132-R167) [[5]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543L184-R224) [[6]](diffhunk://#diff-b5dc9db6edafc51226969611926bccf40aa255d2e5da049c39f5fe833b0f8543L412-R488)

These changes significantly enhance the accuracy and completeness of asset usage detection, especially in codebases that pass resources through multiple layers of user-defined types.