### PR TITLE
Add version flag and update release task

### DIFF
--- a/Sources/SUR/SUR.swift
+++ b/Sources/SUR/SUR.swift
@@ -34,7 +34,6 @@ struct SUR: AsyncParsableCommand {
             return
         }
 
-
         let showWarnings = ProcessInfo.processInfo.environment["XCODE_PRODUCT_BUILD_VERSION"] != nil
 
         let projectPath: Path

--- a/Sources/SUR/SUR.swift
+++ b/Sources/SUR/SUR.swift
@@ -12,18 +12,29 @@ import Rainbow
 import SURCore
 
 struct SUR: AsyncParsableCommand {
+    static let version = "0.3.0"
+
     static let configuration = CommandConfiguration(
         commandName: "sur",
         abstract: "Find unused resources"
     )
-    
+
     @Option(name: .shortAndLong, help: "Root path of your Xcode project. Default is current.", transform: { Path($0) })
     var project: Path?
-    
+
     @Option(name: .shortAndLong, help: "Project's target. Skip to process all targets.")
     var target: String?
-    
+
+    @Flag(name: [.customShort("v"), .long], help: "Show the version.")
+    var version = false
+
     func run() async throws {
+        if version {
+            print(Self.version)
+            return
+        }
+
+
         let showWarnings = ProcessInfo.processInfo.environment["XCODE_PRODUCT_BUILD_VERSION"] != nil
 
         let projectPath: Path

--- a/mise.toml
+++ b/mise.toml
@@ -60,7 +60,7 @@ echo "Artifact bundle created: $BUNDLE_ZIP"
 '''
 
 [tasks.update-version]
-description = "Update version in podspec and Package.swift"
+description = "Update version in podspec, Package.swift and SUR.swift"
 run = '''
 #!/usr/bin/env bash
 set -e
@@ -76,7 +76,10 @@ sed -i '' -E "s/(spec.version[[:space:]]*=[[:space:]]*')[^']+'/\1$VERSION'/" Swi
 # 2. Update Package.swift version in URL
 sed -i '' -E "s|(releases/download/)[^/]+/(sur-).+(\.artifactbundle\.zip)|\1$VERSION/\2$VERSION\3|" Package.swift
 
-# 3. Update checksum (if zip exists)
+# 3. Update version constant in SUR.swift
+sed -i '' -E "s/(static let version = \")[^\"]+(\")/\1$VERSION\2/" Sources/SUR/SUR.swift
+
+# 4. Update checksum (if zip exists)
 BUNDLE_ZIP="sur-$VERSION.artifactbundle.zip"
 if [ -f "$BUNDLE_ZIP" ]; then
     echo "Found $BUNDLE_ZIP, updating checksum..."


### PR DESCRIPTION
Add an in-binary version constant and a -v/--version flag to the sur CLI (prints version and exits). Update mise.toml task description and release script to also update the new static let version in Sources/SUR/SUR.swift during version bumps. Minor formatting/whitespace adjustments included.